### PR TITLE
Elasticsearch 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+
+    // elasticsearch
+    implementation 'co.elastic.clients:elasticsearch-java:9.0.1'
+
 }
 tasks.withType(JavaCompile) {
     options.annotationProcessorPath = configurations.annotationProcessor

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ dependencies {
 
     // elasticsearch
     implementation 'co.elastic.clients:elasticsearch-java:9.0.1'
+    implementation "org.elasticsearch.client:elasticsearch-rest-client:8.15.3"
 
 }
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/example/momentix/config/ElasticsearchConfig.java
+++ b/src/main/java/com/example/momentix/config/ElasticsearchConfig.java
@@ -1,0 +1,5 @@
+package com.example.momentix.config;
+
+//자바 클라이언트 Bean (URL/API Key/Cloud ID)
+public class ElasticsearchConfig {
+}

--- a/src/main/java/com/example/momentix/config/ElasticsearchConfig.java
+++ b/src/main/java/com/example/momentix/config/ElasticsearchConfig.java
@@ -1,5 +1,36 @@
 package com.example.momentix.config;
 
-//자바 클라이언트 Bean (URL/API Key/Cloud ID)
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+//// 엘라스틱서치와 연결 설정하는 곳
+@Configuration
 public class ElasticsearchConfig {
+    @Value("${elasticsearch.url}")
+    private String serverUrl;
+
+    @Value("${elasticsearch.apikey}")
+    private String apiKey;
+
+    //스프링이 사용할 엘라스틱서치 클라이언트 만들기(Bean 등록
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        // // HTTP로 엘라스틱서치에 붙는 기본 클라이언트
+        RestClient restClient = RestClient.builder(HttpHost.create(serverUrl))
+                //// 요청 보낼 때 항상 Authorization 헤더( ApiKey … ) 붙이기
+                .setDefaultHeaders(new org.apache.http.Header[]{
+                        new org.apache.http.message.BasicHeader("Authorization", "ApiKey " + apiKey)
+                })
+                .build();
+        // 위 RestClient를 엘라스틱 자바 클라이언트가 쓰도록 감싸주기(전송/매퍼 설정)
+        RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        // 실제로 우리가 사용할 고수준 클라이언트
+        return new ElasticsearchClient(transport);
+    }
 }

--- a/src/main/java/com/example/momentix/domain/common/elasticsearch/IndexNames.java
+++ b/src/main/java/com/example/momentix/domain/common/elasticsearch/IndexNames.java
@@ -1,0 +1,32 @@
+package com.example.momentix.domain.common.elasticsearch;
+
+public final class IndexNames {
+    private IndexNames() {}
+    public static final String EVENTS = "events";
+
+    // --- fields (ES mapping과 정확히 일치시켜야 함)
+    public static final String FIELD_EVENT_TITLE = "eventTitle";
+    public static final String FIELD_EVENT_TITLE_SUGGEST = "eventTitle_suggest";
+    public static final String FIELD_PLACE_NAME = "placeName";
+    public static final String FIELD_PLACE_NAME_SUGGEST = "placeName_suggest";
+    public static final String FIELD_PLACE_ADDR = "placeAddress";
+    public static final String FIELD_CATEGORY = "eventCategory";
+    public static final String FIELD_START = "eventStartDate";
+    public static final String FIELD_END = "eventEndDate";
+
+    // --- search logs
+    public static final String SEARCH_LOGS_PATTERN = "search-logs-*";
+    public static final String FIELD_QUERY = "query";
+    public static final String FIELD_QUERY_KEYWORD = "query.keyword";
+    public static final String FIELD_TIMESTAMP = "@timestamp";
+
+    // --- aggs
+    public static final String AGG_PER_HOUR = "per_hour";
+    public static final String AGG_POPULAR = "popular";
+
+    public static final String TIME_ZONE_SEOUL = "Asia/Seoul";
+
+    public static final int DEFAULT_SUGGEST_SIZE = 10;
+
+    public static final String SEARCH_LOGS_INDEX = "search-logs-0001";
+}

--- a/src/main/java/com/example/momentix/domain/common/elasticsearch/IndexNames.java
+++ b/src/main/java/com/example/momentix/domain/common/elasticsearch/IndexNames.java
@@ -1,32 +1,39 @@
 package com.example.momentix.domain.common.elasticsearch;
 
+// 상수 모음(객체로 절대 만들지 말 것)
 public final class IndexNames {
     private IndexNames() {}
+
+    //이벤트 데이터가 저장되는 인덱스 이름
     public static final String EVENTS = "events";
 
-    // --- fields (ES mapping과 정확히 일치시켜야 함)
-    public static final String FIELD_EVENT_TITLE = "eventTitle";
-    public static final String FIELD_EVENT_TITLE_SUGGEST = "eventTitle_suggest";
-    public static final String FIELD_PLACE_NAME = "placeName";
-    public static final String FIELD_PLACE_NAME_SUGGEST = "placeName_suggest";
-    public static final String FIELD_PLACE_ADDR = "placeAddress";
-    public static final String FIELD_CATEGORY = "eventCategory";
-    public static final String FIELD_START = "eventStartDate";
-    public static final String FIELD_END = "eventEndDate";
+    // 이벤트 문서의 필드 이름들
+    public static final String FIELD_EVENT_TITLE = "eventTitle"; // 공연 제목
+    public static final String FIELD_EVENT_TITLE_SUGGEST = "eventTitle_suggest"; // 제목 자동완성용 필드
+    public static final String FIELD_PLACE_NAME = "placeName";// 공연장 이름
+    public static final String FIELD_PLACE_NAME_SUGGEST = "placeName_suggest";// 공연장 자동완성용 필드
+    public static final String FIELD_PLACE_ADDR = "placeAddress"; // 공연장 주소
+    public static final String FIELD_CATEGORY = "eventCategory"; // 공연 카테고리
+    public static final String FIELD_START = "eventStartDate"; // 공연 시작일
+    public static final String FIELD_END = "eventEndDate"; // 공연 종료일
 
-    // --- search logs
-    public static final String SEARCH_LOGS_PATTERN = "search-logs-*";
-    public static final String FIELD_QUERY = "query";
-    public static final String FIELD_QUERY_KEYWORD = "query.keyword";
-    public static final String FIELD_TIMESTAMP = "@timestamp";
+    // 검색 로그 관련
+    public static final String SEARCH_LOGS_PATTERN = "search-logs-*"; // 검색 로그 인덱스 패턴
+    public static final String FIELD_QUERY = "query"; // 사용자가 입력한 검색어
+    public static final String FIELD_QUERY_KEYWORD = "query.keyword"; // 검색어(키워드 형태, 집계용)
+    public static final String FIELD_TIMESTAMP = "@timestamp"; // 로그가 기록된 시각
 
-    // --- aggs
-    public static final String AGG_PER_HOUR = "per_hour";
-    public static final String AGG_POPULAR = "popular";
 
-    public static final String TIME_ZONE_SEOUL = "Asia/Seoul";
+    //  집계(aggregation) 이름
+    public static final String AGG_PER_HOUR = "per_hour";// 시간대별 집계
+    public static final String AGG_POPULAR = "popular";// 인기 검색어 집계
 
-    public static final int DEFAULT_SUGGEST_SIZE = 10;
+    // 시간대
+    public static final String TIME_ZONE_SEOUL = "Asia/Seoul"; // 한국 시간대 기준으로 집계
 
-    public static final String SEARCH_LOGS_INDEX = "search-logs-0001";
+    //기본값
+    public static final int DEFAULT_SUGGEST_SIZE = 10; // 자동완성 기본 개수
+
+    // 검색 로그 인덱스 이름
+    public static final String SEARCH_LOGS_INDEX = "search-logs-0001";// 실제 저장되는 검색 로그 인덱스
 }

--- a/src/main/java/com/example/momentix/domain/events/repository/EventsRepositoryCustomImpl.java
+++ b/src/main/java/com/example/momentix/domain/events/repository/EventsRepositoryCustomImpl.java
@@ -124,6 +124,15 @@ public class EventsRepositoryCustomImpl implements EventsRepositoryCustom {
         }
     }
 
+    // 키워드 필터: 제목/장소명/주소 매칭
+    private BooleanExpression keyword(String q) {
+        if (q == null || q.isBlank()) return null;
+        String like = "%" + q.trim() + "%";
+        return QEvents.events.eventTitle.likeIgnoreCase(like)
+                .or(QPlaces.places.placeName.likeIgnoreCase(like))
+                .or(QPlaces.places.placeAddress.likeIgnoreCase(like));
+    }
+
     public Page<SearchResponseDto> searchEventByParam(SearchRequestDto searchRequestDto, Pageable pageable) {
         QEvents events = QEvents.events;
         QPlaces places = QPlaces.places;
@@ -143,7 +152,8 @@ public class EventsRepositoryCustomImpl implements EventsRepositoryCustom {
                         categoryType(searchRequestDto.getEventCategory()),
                         regionAddress(searchRequestDto.getRegion()),
                         title(searchRequestDto.getEventTitle()),
-                        period(searchRequestDto.getSearchStartDate(), searchRequestDto.getSearchEndDate())
+                        period(searchRequestDto.getSearchStartDate(), searchRequestDto.getSearchEndDate()),
+                        keyword(searchRequestDto.getQuery())
                 )
                 .offset(pageable.getOffset())   // (2) 페이지 번호
                 .limit(pageable.getPageSize())  // (3) 페이지 사이즈
@@ -161,7 +171,8 @@ public class EventsRepositoryCustomImpl implements EventsRepositoryCustom {
                         categoryType(searchRequestDto.getEventCategory()),
                         regionAddress(searchRequestDto.getRegion()),
                         title(searchRequestDto.getEventTitle()),
-                        period(searchRequestDto.getSearchStartDate(), searchRequestDto.getSearchEndDate())
+                        period(searchRequestDto.getSearchStartDate(), searchRequestDto.getSearchEndDate()),
+                        keyword(searchRequestDto.getQuery())
                 )
                 .fetchOne()).orElse(0L);
 

--- a/src/main/java/com/example/momentix/domain/search/bootstrap/EventIndexBootstrapper.java
+++ b/src/main/java/com/example/momentix/domain/search/bootstrap/EventIndexBootstrapper.java
@@ -1,0 +1,38 @@
+package com.example.momentix.domain.search.bootstrap;
+
+
+import com.example.momentix.domain.search.bootstrap.service.EventIndexService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+// 자동완성 엘라스틱 데브 툴에 매번 넣기 힘들어서 자동화만듦
+// 앱 시작 시 발동
+@Configuration
+public class EventIndexBootstrapper  {
+    private static final Logger log = LoggerFactory.getLogger(EventIndexBootstrapper.class);
+
+    private final EventIndexService eventIndexService;
+
+    public EventIndexBootstrapper(EventIndexService eventIndexService) {
+        this.eventIndexService = eventIndexService;
+    }
+
+    @Bean
+    public ApplicationRunner initEventIndex() {
+        return args -> {
+            try {
+                // 1) 인덱스 없으면 생성
+                eventIndexService.ensureEventsIndex();
+                // 2) MySQL 데이터 전부 재색인
+                eventIndexService.reindexAllFromMySQL();
+                log.info("[ES] Bootstrap finished");
+            } catch (Exception e) {
+                log.error("[ES] Bootstrap failed", e);
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/momentix/domain/search/bootstrap/EventIndexBootstrapper.java
+++ b/src/main/java/com/example/momentix/domain/search/bootstrap/EventIndexBootstrapper.java
@@ -5,32 +5,44 @@ import com.example.momentix.domain.search.bootstrap.service.EventIndexService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 
-// 자동완성 엘라스틱 데브 툴에 매번 넣기 힘들어서 자동화만듦
-// 앱 시작 시 발동
 @Configuration
+@ConditionalOnProperty(name = "search.bootstrap.enabled", havingValue = "true")// 로컬만 켜두고 기본(배표)은 꺼두기
 public class EventIndexBootstrapper  {
+
+    // 실행조건: 설정(search.bootstrap.enabled=true)일 때만 동작
+    // ES 인덱스(테이블 같은 것) 없으면 만들고
+    // MySQL에 있는 이벤트+장소 데이터를 전부 ES에 넣는다
+
+
     private static final Logger log = LoggerFactory.getLogger(EventIndexBootstrapper.class);
 
+
     private final EventIndexService eventIndexService;
+
+
 
     public EventIndexBootstrapper(EventIndexService eventIndexService) {
         this.eventIndexService = eventIndexService;
     }
 
+
+    //스프링 부트가 켜질 때 자동으로 한 번 실행됨
     @Bean
     public ApplicationRunner initEventIndex() {
         return args -> {
             try {
-                // 1) 인덱스 없으면 생성
+                // 1) ES에 events 인덱스(테이블 같은 것) 없으면 생성
                 eventIndexService.ensureEventsIndex();
-                // 2) MySQL 데이터 전부 재색인
+                // 1) ES에 events 인덱스(테이블 같은 것) 없으면 생성
                 eventIndexService.reindexAllFromMySQL();
                 log.info("[ES] Bootstrap finished");
             } catch (Exception e) {
+                // 실패해도 서버 전체는 계속 올라가도록 로그만 남김
                 log.error("[ES] Bootstrap failed", e);
             }
         };

--- a/src/main/java/com/example/momentix/domain/search/bootstrap/dco/EventDoc.java
+++ b/src/main/java/com/example/momentix/domain/search/bootstrap/dco/EventDoc.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class EventDoc {
-    // 기본 검색 필드
+    // 검색/필터용 기본 정보
     private final String eventId;
     private final String eventTitle;
     private final String eventCategory;
@@ -48,6 +48,7 @@ public class EventDoc {
         this.placeNameSuggest = placeNameSuggest;
     }
 
+    // 자동완성에 들어갈 값들
     @Getter
     public static class SuggestField {
         private final List<String> input;

--- a/src/main/java/com/example/momentix/domain/search/bootstrap/dco/EventDoc.java
+++ b/src/main/java/com/example/momentix/domain/search/bootstrap/dco/EventDoc.java
@@ -1,0 +1,61 @@
+package com.example.momentix.domain.search.bootstrap.dco;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+//적재할 문서
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EventDoc {
+    // 기본 검색 필드
+    private final String eventId;
+    private final String eventTitle;
+    private final String eventCategory;
+    private final String eventStartDate;
+    private final String eventEndDate;
+    private final String placeName;
+    private final String placeAddress;
+
+    // 자동완성(completion)
+    @JsonProperty("eventTitle_suggest")
+    private final SuggestField eventTitleSuggest;
+
+    @JsonProperty("placeName_suggest")
+    private final SuggestField placeNameSuggest;
+
+    public EventDoc(
+            String eventId,
+            String eventTitle,
+            String eventCategory,
+            String eventStartDate,
+            String eventEndDate,
+            String placeName,
+            String placeAddress,
+            SuggestField eventTitleSuggest,
+            SuggestField placeNameSuggest
+    ) {
+        this.eventId = eventId;
+        this.eventTitle = eventTitle;
+        this.eventCategory = eventCategory;
+        this.eventStartDate = eventStartDate;
+        this.eventEndDate = eventEndDate;
+        this.placeName = placeName;
+        this.placeAddress = placeAddress;
+        this.eventTitleSuggest = eventTitleSuggest;
+        this.placeNameSuggest = placeNameSuggest;
+    }
+
+    @Getter
+    public static class SuggestField {
+        private final List<String> input;
+        private final Integer weight;
+
+        public SuggestField(List<String> input, Integer weight) {
+            this.input = input;
+            this.weight = weight;
+        }
+    }
+}

--- a/src/main/java/com/example/momentix/domain/search/bootstrap/service/EventIndexService.java
+++ b/src/main/java/com/example/momentix/domain/search/bootstrap/service/EventIndexService.java
@@ -1,0 +1,141 @@
+package com.example.momentix.domain.search.bootstrap.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.ExistsRequest;
+import com.example.momentix.domain.common.elasticsearch.IndexNames;
+import com.example.momentix.domain.events.entity.QEventPlace;
+import com.example.momentix.domain.events.entity.QEvents;
+import com.example.momentix.domain.events.entity.places.QPlaces;
+import com.example.momentix.domain.search.bootstrap.dco.EventDoc;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+//인덱스 생성 + MySQL → ES 재색인 로직
+@Service
+public class EventIndexService {
+    private static final Logger log = LoggerFactory.getLogger(EventIndexService.class);
+
+    private final ElasticsearchClient es;
+    private final JPAQueryFactory queryFactory;
+
+    private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public EventIndexService(ElasticsearchClient es, JPAQueryFactory queryFactory) {
+        this.es = es;
+        this.queryFactory = queryFactory;
+    }
+
+    public void ensureEventsIndex() throws Exception {
+        boolean exists = es.indices().exists(ExistsRequest.of(b -> b.index(IndexNames.EVENTS))).value();
+        if (exists) {
+            log.info("[ES] '{}' already exists", IndexNames.EVENTS);
+            return;
+        }
+
+        CreateIndexRequest req = CreateIndexRequest.of(ci -> ci
+                .index(IndexNames.EVENTS)
+                .mappings(m -> m
+                        .properties("eventCategory", p -> p.keyword(k -> k))
+                        .properties("eventEndDate", p -> p.date(d -> d.format("yyyy-MM-dd||strict_date_optional_time||epoch_millis")))
+                        .properties("eventId", p -> p.text(t -> t.fields("keyword", f -> f.keyword(kb -> kb.ignoreAbove(256)))))
+                        .properties("eventStartDate", p -> p.date(d -> d.format("yyyy-MM-dd||strict_date_optional_time||epoch_millis")))
+                        .properties("eventTitle", p -> p.text(t -> t.fields("keyword", f -> f.keyword(k -> k))))
+                        .properties("placeAddress", p -> p.text(t -> t))
+                        .properties("placeName", p -> p.text(t -> t.fields("keyword", f -> f.keyword(k -> k))))
+                        .properties("eventTitle_suggest", p -> p.completion(comp1 -> comp1
+                                .analyzer("simple")
+                                .preserveSeparators(true)
+                                .preservePositionIncrements(true)
+                                .maxInputLength(50)))
+                        .properties("placeName_suggest", p -> p.completion(comp2 -> comp2
+                                .analyzer("simple")
+                                .preserveSeparators(true)
+                                .preservePositionIncrements(true)
+                                .maxInputLength(50)))
+                )
+        );
+
+        es.indices().create(req);
+        log.info("[ES] Created index '{}'", IndexNames.EVENTS);
+    }
+
+    public void reindexAllFromMySQL() throws Exception {
+        QEvents e = QEvents.events;
+        QEventPlace ep = QEventPlace.eventPlace;
+        QPlaces p = QPlaces.places;
+
+        List<Tuple> rows = queryFactory
+                .select(
+                        e.id, p.id, e.eventTitle, e.eventCategoryType,
+                        e.eventStartDate, e.eventEndDate,
+                        p.placeName, p.placeAddress
+                )
+                .from(e)
+                .join(e.eventPlaceList, ep)
+                .join(ep.places, p)
+                .where(e.isDeleted.eq(false))
+                .fetch();
+
+        if (rows.isEmpty()) {
+            log.info("[ES] No data to index");
+            return;
+        }
+
+        List<BulkOperation> ops = new ArrayList<>(rows.size());
+        for (Tuple t : rows) {
+            Long eventId = t.get(e.id);
+            Long placeId = t.get(p.id);
+
+            String esId = eventId + "-" + placeId;
+
+            String eventTitle = t.get(e.eventTitle);
+            String eventCategory = t.get(e.eventCategoryType).name();
+            String start = DF.format(t.get(e.eventStartDate));
+            String end   = DF.format(t.get(e.eventEndDate));
+            String placeName = t.get(p.placeName);
+            String placeAddress = t.get(p.placeAddress);
+
+            EventDoc.SuggestField titleSg = new EventDoc.SuggestField(
+                    List.of(eventTitle), null
+            );
+            EventDoc.SuggestField placeSg = new EventDoc.SuggestField(
+                    List.of(placeName), null
+            );
+
+            EventDoc doc = new EventDoc(
+                    String.valueOf(eventId),
+                    eventTitle,
+                    eventCategory,
+                    start,
+                    end,
+                    placeName,
+                    placeAddress,
+                    titleSg,
+                    placeSg
+            );
+
+            ops.add(BulkOperation.of(b -> b.index(idx -> idx
+                    .index(IndexNames.EVENTS)
+                    .id(esId)
+                    .document(doc))));
+        }
+
+        BulkResponse resp = es.bulk(BulkRequest.of(b -> b.operations(ops)));
+        if (Boolean.TRUE.equals(resp.errors())) {
+            log.warn("[ES] Bulk indexing had errors: {}", resp);
+        } else {
+            log.info("[ES] Indexed {} docs into '{}'", ops.size(), IndexNames.EVENTS);
+        }
+    }
+}

--- a/src/main/java/com/example/momentix/domain/search/bootstrap/service/EventIndexService.java
+++ b/src/main/java/com/example/momentix/domain/search/bootstrap/service/EventIndexService.java
@@ -24,35 +24,55 @@ import java.util.List;
 //인덱스 생성 + MySQL → ES 재색인 로직
 @Service
 public class EventIndexService {
+
     private static final Logger log = LoggerFactory.getLogger(EventIndexService.class);
 
-    private final ElasticsearchClient es;
-    private final JPAQueryFactory queryFactory;
+    private final ElasticsearchClient elasticsearchClient; // ES 연결 클라이언트
 
+    private final JPAQueryFactory queryFactory; // MySQL 조회용(QueryDSL)
+
+
+    // 날짜를 "yyyy-MM-dd" 문자열로 맞춰서 넣기(ES date 매핑과 호환)
     private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    public EventIndexService(ElasticsearchClient es, JPAQueryFactory queryFactory) {
-        this.es = es;
+
+
+    public EventIndexService(ElasticsearchClient elasticsearchClient, JPAQueryFactory queryFactory) {
+        this.elasticsearchClient = elasticsearchClient;
         this.queryFactory = queryFactory;
     }
 
+
+
+    //인덱스 없으면 매핑과 함께 생성
     public void ensureEventsIndex() throws Exception {
-        boolean exists = es.indices().exists(ExistsRequest.of(b -> b.index(IndexNames.EVENTS))).value();
+        boolean exists = elasticsearchClient.indices().exists(ExistsRequest.of(b -> b.index(IndexNames.EVENTS))).value();
         if (exists) {
-            log.info("[ES] '{}' already exists", IndexNames.EVENTS);
+            log.info("[ES] '{}' 이미 존재합니다.", IndexNames.EVENTS);
             return;
         }
 
         CreateIndexRequest req = CreateIndexRequest.of(ci -> ci
                 .index(IndexNames.EVENTS)
                 .mappings(m -> m
+                        // 카테고리: 정확히 일치 검색(=keyword)
                         .properties("eventCategory", p -> p.keyword(k -> k))
+
+                        // 날짜
                         .properties("eventEndDate", p -> p.date(d -> d.format("yyyy-MM-dd||strict_date_optional_time||epoch_millis")))
+
+                        // eventId: 텍스트지만 keyword 서브필드로도 보관
                         .properties("eventId", p -> p.text(t -> t.fields("keyword", f -> f.keyword(kb -> kb.ignoreAbove(256)))))
+
+                        // 제목/장소이름
                         .properties("eventStartDate", p -> p.date(d -> d.format("yyyy-MM-dd||strict_date_optional_time||epoch_millis")))
                         .properties("eventTitle", p -> p.text(t -> t.fields("keyword", f -> f.keyword(k -> k))))
                         .properties("placeAddress", p -> p.text(t -> t))
+
+                        // 주소
                         .properties("placeName", p -> p.text(t -> t.fields("keyword", f -> f.keyword(k -> k))))
+
+                        // 자동완성용 필드(Completion 타입)
                         .properties("eventTitle_suggest", p -> p.completion(comp1 -> comp1
                                 .analyzer("simple")
                                 .preserveSeparators(true)
@@ -66,15 +86,19 @@ public class EventIndexService {
                 )
         );
 
-        es.indices().create(req);
-        log.info("[ES] Created index '{}'", IndexNames.EVENTS);
+        elasticsearchClient.indices().create(req);
+        log.info("[ES] 생성된 인덱스 '{}'", IndexNames.EVENTS);
     }
 
+
+
+    //MySQL → ES로 전부 넣기
     public void reindexAllFromMySQL() throws Exception {
         QEvents e = QEvents.events;
         QEventPlace ep = QEventPlace.eventPlace;
         QPlaces p = QPlaces.places;
 
+        //이벤트×장소 매핑이 있는 데이터만 뽑기
         List<Tuple> rows = queryFactory
                 .select(
                         e.id, p.id, e.eventTitle, e.eventCategoryType,
@@ -88,7 +112,7 @@ public class EventIndexService {
                 .fetch();
 
         if (rows.isEmpty()) {
-            log.info("[ES] No data to index");
+            log.info("[ES] 인덱스를 생성할 데이터가 없습니다.");
             return;
         }
 
@@ -97,6 +121,7 @@ public class EventIndexService {
             Long eventId = t.get(e.id);
             Long placeId = t.get(p.id);
 
+            //ES 문서 ID를 "이벤트ID-장소ID"로 고정 → 중복 없이 덮어쓰기 쉬움
             String esId = eventId + "-" + placeId;
 
             String eventTitle = t.get(e.eventTitle);
@@ -106,6 +131,7 @@ public class EventIndexService {
             String placeName = t.get(p.placeName);
             String placeAddress = t.get(p.placeAddress);
 
+            // 자동완성
             EventDoc.SuggestField titleSg = new EventDoc.SuggestField(
                     List.of(eventTitle), null
             );
@@ -113,6 +139,7 @@ public class EventIndexService {
                     List.of(placeName), null
             );
 
+            // ES에 넣을 한 문서 만들기
             EventDoc doc = new EventDoc(
                     String.valueOf(eventId),
                     eventTitle,
@@ -131,11 +158,12 @@ public class EventIndexService {
                     .document(doc))));
         }
 
-        BulkResponse resp = es.bulk(BulkRequest.of(b -> b.operations(ops)));
+        // 한 방에 전송
+        BulkResponse resp = elasticsearchClient.bulk(BulkRequest.of(b -> b.operations(ops)));
         if (Boolean.TRUE.equals(resp.errors())) {
-            log.warn("[ES] Bulk indexing had errors: {}", resp);
+            log.warn("[ES] 대량 인덱싱에 오류: {}", resp);
         } else {
-            log.info("[ES] Indexed {} docs into '{}'", ops.size(), IndexNames.EVENTS);
+            log.info("[ES] {} 문서를 '{}'에 인덱싱했습니다.", ops.size(), IndexNames.EVENTS);
         }
     }
 }

--- a/src/main/java/com/example/momentix/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/momentix/domain/search/controller/SearchController.java
@@ -17,21 +17,29 @@ import java.util.List;
 @RestController
 @RequestMapping("/search")
 public class SearchController {
+
     private final SearchService searchService;
 
     public SearchController(SearchService searchService) {
         this.searchService = searchService;
     }
 
+
+
     @GetMapping
     public ResponseEntity<Page<SearchResponseDto>> searchEvent(
             @ModelAttribute SearchRequestDto searchRequestDto,
             Pageable pageable,
-            HttpServletRequest request,
+            HttpServletRequest request, // 클라이언트 요청 정보 (IP 등)
             @AuthenticationPrincipal(expression = "userId") Long userId
     ) {
         Page<SearchResponseDto> response = searchService.searchEvent(searchRequestDto, pageable);
-        // 카테고리/startDate/endDate같은 필터도 있으면 같이 기록되게
+
+
+        // 검색 로그를 저장(검색어, 카테고리, 기간, 사용자, IP 등)
+        /// 검색 결과를 반호나하는 것과 동시에 (비동기)
+        // 뒤에서 몰래 기록 작업이 처리 됨(사용자가 기다릴 필요 없음)
+        
         searchService.logSearchAsync(
                 searchRequestDto,
                 (userId == null) ? null : String.valueOf(userId),
@@ -41,6 +49,8 @@ public class SearchController {
         return ResponseEntity.ok(response);
     }
 
+    // 사용자의 진짜 IP주소 가져오기
+    // 중간 서버를 거칠 수 있어서 헤더 값에서 먼저 꺼내보고 없으면 기본 IP 사용
     private String extractClientIp(HttpServletRequest req) {
         String xff = req.getHeader("X-Forwarded-For");
         if (xff != null && !xff.isBlank())
@@ -49,13 +59,15 @@ public class SearchController {
         return (realIp != null && !realIp.isBlank()) ? realIp : req.getRemoteAddr();
     }
 
-    // 자동완성
+
+    // 자동완성- 그 글자로 시작하는 추천 단어
     @GetMapping("/autocomplete")
     public List<AutocompleteResponse> autocomplete(
             @RequestParam("q") String query,
             @RequestParam(value = "size", defaultValue = "10") int size) {
         return searchService.autocomplete(query, size);
     }
+
 
     // 인기검색어
     @GetMapping("/popular-queries")
@@ -64,6 +76,7 @@ public class SearchController {
             @RequestParam(value = "size", defaultValue = "10") int size) {
         return searchService.popularQueries(hours, size);
     }
+
 
     // 시간대별 건수
     @GetMapping("/hourly-counts")

--- a/src/main/java/com/example/momentix/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/momentix/domain/search/controller/SearchController.java
@@ -72,7 +72,7 @@ public class SearchController {
     // 인기검색어
     @GetMapping("/popular-queries")
     public List<AutocompleteResponse> popularQueries(
-            @RequestParam(value = "hours", defaultValue = "24") int hours,
+            @RequestParam(value = "hours", defaultValue = "1") int hours,
             @RequestParam(value = "size", defaultValue = "10") int size) {
         return searchService.popularQueries(hours, size);
     }
@@ -81,7 +81,7 @@ public class SearchController {
     // 시간대별 건수
     @GetMapping("/hourly-counts")
     public List<HourlyCountBucket> hourlyCounts(
-            @RequestParam(value = "hours", defaultValue = "24") int hours) {
+            @RequestParam(value = "hours", defaultValue = "1") int hours) {
         return searchService.hourlyCounts(hours);
     }
 }

--- a/src/main/java/com/example/momentix/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/momentix/domain/search/controller/SearchController.java
@@ -1,28 +1,74 @@
 package com.example.momentix.domain.search.controller;
 
+import com.example.momentix.domain.search.dto.AutocompleteResponse;
+import com.example.momentix.domain.search.dto.HourlyCountBucket;
 import com.example.momentix.domain.search.dto.SearchRequestDto;
 import com.example.momentix.domain.search.dto.SearchResponseDto;
 import com.example.momentix.domain.search.service.SearchService;
-import lombok.RequiredArgsConstructor;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/search")
 public class SearchController {
     private final SearchService searchService;
 
-    @GetMapping
+    public SearchController(SearchService searchService) {
+        this.searchService = searchService;
+    }
 
-    public ResponseEntity<Page<SearchResponseDto>> searchEvent(@ModelAttribute SearchRequestDto searchRequestdto, Pageable pageable) {
-        Page<SearchResponseDto> response = searchService.searchEvent(searchRequestdto, pageable);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+    @GetMapping
+    public ResponseEntity<Page<SearchResponseDto>> searchEvent(
+            @ModelAttribute SearchRequestDto searchRequestDto,
+            Pageable pageable,
+            HttpServletRequest request,
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        Page<SearchResponseDto> response = searchService.searchEvent(searchRequestDto, pageable);
+        // 카테고리/startDate/endDate같은 필터도 있으면 같이 기록되게
+        searchService.logSearchAsync(
+                searchRequestDto,
+                (userId == null) ? null : String.valueOf(userId),
+                extractClientIp(request)
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    private String extractClientIp(HttpServletRequest req) {
+        String xff = req.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank())
+            return xff.split(",")[0].trim();
+        String realIp = req.getHeader("X-Real-IP");
+        return (realIp != null && !realIp.isBlank()) ? realIp : req.getRemoteAddr();
+    }
+
+    // 자동완성
+    @GetMapping("/autocomplete")
+    public List<AutocompleteResponse> autocomplete(
+            @RequestParam("q") String query,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+        return searchService.autocomplete(query, size);
+    }
+
+    // 인기검색어
+    @GetMapping("/popular-queries")
+    public List<AutocompleteResponse> popularQueries(
+            @RequestParam(value = "hours", defaultValue = "24") int hours,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+        return searchService.popularQueries(hours, size);
+    }
+
+    // 시간대별 건수
+    @GetMapping("/hourly-counts")
+    public List<HourlyCountBucket> hourlyCounts(
+            @RequestParam(value = "hours", defaultValue = "24") int hours) {
+        return searchService.hourlyCounts(hours);
     }
 }

--- a/src/main/java/com/example/momentix/domain/search/dto/AutocompleteResponse.java
+++ b/src/main/java/com/example/momentix/domain/search/dto/AutocompleteResponse.java
@@ -1,6 +1,20 @@
 package com.example.momentix.domain.search.dto;
 
 
-//자동완성 전용 응답
+// 자동완성/인기검색어 공통으로 쓰는 응답 형태
 public class AutocompleteResponse {
+    private String suggestion;//추천 단어
+    private long count;//해당 단어 몇 번 나왔는지(인기검색어용)
+
+    public AutocompleteResponse() {}
+
+    public AutocompleteResponse(String suggestion, long count) {
+        this.suggestion = suggestion;
+        this.count = count;
+    }
+
+    public String getSuggestion() { return suggestion; }
+    public void setSuggestion(String suggestion) { this.suggestion = suggestion; }
+    public long getCount() { return count; }
+    public void setCount(long count) { this.count = count; }
 }

--- a/src/main/java/com/example/momentix/domain/search/dto/AutocompleteResponse.java
+++ b/src/main/java/com/example/momentix/domain/search/dto/AutocompleteResponse.java
@@ -1,0 +1,6 @@
+package com.example.momentix.domain.search.dto;
+
+
+//자동완성 전용 응답
+public class AutocompleteResponse {
+}

--- a/src/main/java/com/example/momentix/domain/search/dto/AutocompleteResponse.java
+++ b/src/main/java/com/example/momentix/domain/search/dto/AutocompleteResponse.java
@@ -1,7 +1,7 @@
 package com.example.momentix.domain.search.dto;
 
 
-// 자동완성/인기검색어 공통으로 쓰는 응답 형태
+//  "권지용" 검색하면 → suggestion = "권지용", count = 123
 public class AutocompleteResponse {
     private String suggestion;//추천 단어
     private long count;//해당 단어 몇 번 나왔는지(인기검색어용)

--- a/src/main/java/com/example/momentix/domain/search/dto/HourlyCountBucket.java
+++ b/src/main/java/com/example/momentix/domain/search/dto/HourlyCountBucket.java
@@ -1,5 +1,22 @@
 package com.example.momentix.domain.search.dto;
 
-//시간대별 문서 수 카운트 응답
+
+import java.time.LocalDateTime;
+
+// 시간대별 문서 개수(검색 로그 개수) 한 칸
 public class HourlyCountBucket {
+    private LocalDateTime hour;//(Asia/Seoul 기준)
+    private long count;// 그 시간대에 몇 건인지
+
+    public HourlyCountBucket() {}
+
+    public HourlyCountBucket(LocalDateTime hour, long count) {
+        this.hour = hour;
+        this.count = count;
+    }
+
+    public LocalDateTime getHour() { return hour; }
+    public void setHour(LocalDateTime hour) { this.hour = hour; }
+    public long getCount() { return count; }
+    public void setCount(long count) { this.count = count; }
 }

--- a/src/main/java/com/example/momentix/domain/search/dto/HourlyCountBucket.java
+++ b/src/main/java/com/example/momentix/domain/search/dto/HourlyCountBucket.java
@@ -1,0 +1,5 @@
+package com.example.momentix.domain.search.dto;
+
+//시간대별 문서 수 카운트 응답
+public class HourlyCountBucket {
+}

--- a/src/main/java/com/example/momentix/domain/search/dto/SearchLogDoc.java
+++ b/src/main/java/com/example/momentix/domain/search/dto/SearchLogDoc.java
@@ -1,0 +1,55 @@
+package com.example.momentix.domain.search.dto;
+
+import com.example.momentix.domain.common.elasticsearch.IndexNames;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// 엘라스틱서치에 저장할 검색로그
+public class SearchLogDoc {
+    // @JsonProperty로 엘라스틱 필드 이름을 정확히 맞춰줌
+    @JsonProperty(IndexNames.FIELD_QUERY)
+    private String query;// 사용자가 입력한 검색어
+
+    @JsonProperty(IndexNames.FIELD_CATEGORY)
+    private String category;// 카테고리
+
+    @JsonProperty(IndexNames.FIELD_START)
+    private String startDate;// 기간 시작(문자열로 저장)
+
+    @JsonProperty(IndexNames.FIELD_END)
+    private String endDate;// 기간 끝(문자열로 저장)
+
+    private String userId;
+    private String ip;
+
+    @JsonProperty(IndexNames.FIELD_TIMESTAMP)
+    private long timestamp; // 기록 시간
+
+    public SearchLogDoc() {}
+
+    public SearchLogDoc(String query, String category, String startDate, String endDate,
+                        String userId, String ip, long  timestamp) {
+        this.query = query;
+        this.category = category;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.userId = userId;
+        this.ip = ip;
+        this.timestamp = timestamp;
+    }
+
+    // getters/setters
+    public String getQuery() { return query; }
+    public void setQuery(String query) { this.query = query; }
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+    public String getStartDate() { return startDate; }
+    public void setStartDate(String startDate) { this.startDate = startDate; }
+    public String getEndDate() { return endDate; }
+    public void setEndDate(String endDate) { this.endDate = endDate; }
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+    public String getIp() { return ip; }
+    public void setIp(String ip) { this.ip = ip; }
+    public long  getTimestamp() { return timestamp; }
+    public void setTimestamp(long  timestamp) { this.timestamp = timestamp; }
+}

--- a/src/main/java/com/example/momentix/domain/search/dto/SearchRequestDto.java
+++ b/src/main/java/com/example/momentix/domain/search/dto/SearchRequestDto.java
@@ -15,4 +15,6 @@ public class SearchRequestDto {
     private LocalDate searchEndDate;
     private String region;
 
+    private String query; // 사용자가 입력한 검색어
+
 }

--- a/src/main/java/com/example/momentix/domain/search/impl/AnalyticsRepositoryImpl.java
+++ b/src/main/java/com/example/momentix/domain/search/impl/AnalyticsRepositoryImpl.java
@@ -23,6 +23,11 @@ import java.util.List;
 //집계 구현 (인기검색어/시간대)
 @Repository
 public class AnalyticsRepositoryImpl implements AnalyticsRepository {
+    
+    // 엘라스틱서치에 쌓인 검색 로그를 가지고 
+    // 시간대별 검색 건수, 많이 검색된 단어(인기 검색어)
+    // 를 뽑아오는 클래스
+    
     private final ElasticsearchClient client;
 
     public AnalyticsRepositoryImpl(ElasticsearchClient client) {
@@ -36,7 +41,9 @@ public class AnalyticsRepositoryImpl implements AnalyticsRepository {
 
             SearchResponse<Void> res = client.search(s -> s
                             .index(IndexNames.SEARCH_LOGS_PATTERN)
-                            .size(0)
+
+                            .size(0)// 실제 문서는 안 가져오고(집계만 필요)
+
                             .query(q -> q.range(r -> r
                                     .date(d -> d
                                             .field(IndexNames.FIELD_TIMESTAMP)
@@ -44,29 +51,33 @@ public class AnalyticsRepositoryImpl implements AnalyticsRepository {
                                             .lte("now")
                                     )
                             ))
+
                             .aggregations(IndexNames.AGG_PER_HOUR, a -> a
                                     .dateHistogram(dh -> dh
-                                            .field(IndexNames.FIELD_TIMESTAMP)
-                                            .calendarInterval(CalendarInterval.Hour) // ★ 여기!
-                                            .timeZone(IndexNames.TIME_ZONE_SEOUL)
-                                            .minDocCount(0)
+                                            .field(IndexNames.FIELD_TIMESTAMP)// 시간 자를 기준
+                                            .calendarInterval(CalendarInterval.Hour) // "1시간 단위"로 자르기
+                                            .timeZone(IndexNames.TIME_ZONE_SEOUL)// 한국 시간 기준으로 자르기
+                                            .minDocCount(0)// 빈 시간대도 0으로 채움
                                     )
                             ),
                     Void.class
             );
 
+
+            //집계 결과 꺼내기. 결과가 없으면 빈 리스트
             Aggregate agg = res.aggregations().get(IndexNames.AGG_PER_HOUR);
             if (agg == null || agg.dateHistogram() == null)
                 return List.of();
 
+
             List<HourlyCountBucket> out = new ArrayList<>();
             for (DateHistogramBucket b : agg.dateHistogram().buckets().array()) {
-                long epochMillis = b.key();
+                long epochMillis = b.key();// 시간대 시작 시각
                 LocalDateTime hour = LocalDateTime.ofInstant(
                         Instant.ofEpochMilli(epochMillis),
                         ZoneId.of(IndexNames.TIME_ZONE_SEOUL)
                 );
-                long count = b.docCount();
+                long count = b.docCount();// 그 시간대에 몇 건인지
                 out.add(new HourlyCountBucket(hour, count));
             }
             return out;
@@ -75,8 +86,10 @@ public class AnalyticsRepositoryImpl implements AnalyticsRepository {
         }
     }
 
+
     @Override
     public List<AutocompleteResponse> popularQueries(int hours, int size) {
+        // 기본 24시간, 상위 개수 기본 10개
         try {
             final int window = (hours <= 0) ? 24 : hours;
             final int topN = (size <= 0) ? 10 : size;
@@ -100,14 +113,18 @@ public class AnalyticsRepositoryImpl implements AnalyticsRepository {
                     Void.class
             );
 
+
+            //집계 결과 없으면 빈 리스트
             Aggregate agg = res.aggregations().get(IndexNames.AGG_POPULAR);
             if (agg == null || agg.sterms() == null)
                 return List.of();
 
+
+            //버킷마다 단어/건수 꺼내서 응답 형태로 변환
             List<AutocompleteResponse> out = new ArrayList<>();
             for (StringTermsBucket b : agg.sterms().buckets().array()) {
-                String term = b.key().stringValue();
-                long count = b.docCount();
+                String term = b.key().stringValue();// 검색어
+                long count = b.docCount();// 횟수
                 out.add(new AutocompleteResponse(term, count));
             }
             return out;
@@ -116,6 +133,8 @@ public class AnalyticsRepositoryImpl implements AnalyticsRepository {
         }
     }
 
+
+    // 검색할 때마다 남기는 로그 한 건을 ES에 저장
     @Override
     public void indexSearchLog(SearchLogDoc doc) {
         try {

--- a/src/main/java/com/example/momentix/domain/search/impl/AnalyticsRepositoryImpl.java
+++ b/src/main/java/com/example/momentix/domain/search/impl/AnalyticsRepositoryImpl.java
@@ -1,0 +1,130 @@
+package com.example.momentix.domain.search.impl;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
+import co.elastic.clients.elasticsearch._types.aggregations.DateHistogramBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.example.momentix.domain.common.elasticsearch.IndexNames;
+import com.example.momentix.domain.search.dto.AutocompleteResponse;
+import com.example.momentix.domain.search.dto.HourlyCountBucket;
+import com.example.momentix.domain.search.dto.SearchLogDoc;
+import com.example.momentix.domain.search.repository.AnalyticsRepository;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+//집계 구현 (인기검색어/시간대)
+@Repository
+public class AnalyticsRepositoryImpl implements AnalyticsRepository {
+    private final ElasticsearchClient client;
+
+    public AnalyticsRepositoryImpl(ElasticsearchClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public List<HourlyCountBucket> countPerHour(int hours) {
+        try {
+            final int window = (hours <= 0) ? 24 : hours;
+
+            SearchResponse<Void> res = client.search(s -> s
+                            .index(IndexNames.SEARCH_LOGS_PATTERN)
+                            .size(0)
+                            .query(q -> q.range(r -> r
+                                    .date(d -> d
+                                            .field(IndexNames.FIELD_TIMESTAMP)
+                                            .gte("now-" + window + "h")
+                                            .lte("now")
+                                    )
+                            ))
+                            .aggregations(IndexNames.AGG_PER_HOUR, a -> a
+                                    .dateHistogram(dh -> dh
+                                            .field(IndexNames.FIELD_TIMESTAMP)
+                                            .calendarInterval(CalendarInterval.Hour) // ★ 여기!
+                                            .timeZone(IndexNames.TIME_ZONE_SEOUL)
+                                            .minDocCount(0)
+                                    )
+                            ),
+                    Void.class
+            );
+
+            Aggregate agg = res.aggregations().get(IndexNames.AGG_PER_HOUR);
+            if (agg == null || agg.dateHistogram() == null)
+                return List.of();
+
+            List<HourlyCountBucket> out = new ArrayList<>();
+            for (DateHistogramBucket b : agg.dateHistogram().buckets().array()) {
+                long epochMillis = b.key();
+                LocalDateTime hour = LocalDateTime.ofInstant(
+                        Instant.ofEpochMilli(epochMillis),
+                        ZoneId.of(IndexNames.TIME_ZONE_SEOUL)
+                );
+                long count = b.docCount();
+                out.add(new HourlyCountBucket(hour, count));
+            }
+            return out;
+        } catch (IOException e) {
+            throw new RuntimeException("Elasticsearch countPerHour failed", e);
+        }
+    }
+
+    @Override
+    public List<AutocompleteResponse> popularQueries(int hours, int size) {
+        try {
+            final int window = (hours <= 0) ? 24 : hours;
+            final int topN = (size <= 0) ? 10 : size;
+
+            SearchResponse<Void> res = client.search(s -> s
+                            .index(IndexNames.SEARCH_LOGS_PATTERN)
+                            .size(0)
+                            .query(q -> q.range(r -> r
+                                    .date(d -> d
+                                            .field(IndexNames.FIELD_TIMESTAMP)
+                                            .gte("now-" + window + "h")
+                                            .lte("now")
+                                    )
+                            ))
+                            .aggregations(IndexNames.AGG_POPULAR, a -> a
+                                    .terms(t -> t
+                                            .field(IndexNames.FIELD_QUERY_KEYWORD)
+                                            .size(topN)
+                                    )
+                            ),
+                    Void.class
+            );
+
+            Aggregate agg = res.aggregations().get(IndexNames.AGG_POPULAR);
+            if (agg == null || agg.sterms() == null)
+                return List.of();
+
+            List<AutocompleteResponse> out = new ArrayList<>();
+            for (StringTermsBucket b : agg.sterms().buckets().array()) {
+                String term = b.key().stringValue();
+                long count = b.docCount();
+                out.add(new AutocompleteResponse(term, count));
+            }
+            return out;
+        } catch (IOException e) {
+            throw new RuntimeException("Elasticsearch popularQueries failed", e);
+        }
+    }
+
+    @Override
+    public void indexSearchLog(SearchLogDoc doc) {
+        try {
+            client.index(i -> i
+                    .index(IndexNames.SEARCH_LOGS_INDEX)
+                    .document(doc)
+            );
+        } catch (IOException e) {
+            throw new RuntimeException("Elasticsearch indexSearchLog failed", e);
+        }
+    }
+}

--- a/src/main/java/com/example/momentix/domain/search/impl/SuggestRepositoryImpl.java
+++ b/src/main/java/com/example/momentix/domain/search/impl/SuggestRepositoryImpl.java
@@ -17,10 +17,15 @@ import java.util.*;
 //prefix(원본 텍스트에서 대로 시작하는 필드 직접 검색)
 @Repository
 public class SuggestRepositoryImpl implements SuggestRepository {
+
+    // 1) 미리 준비된 "자동완성용 필드"(completion)에서 추천 먼저 가져오고
+    // 2) 부족하면 실제 텍스트 필드에서 "앞부분 일치(prefix)"로 보충해서 채움
+
     private static final String SG_TITLE = "title-suggest";
     private static final String SG_PLACE = "place-suggest";
 
     private final ElasticsearchClient client;
+
 
     public SuggestRepositoryImpl(ElasticsearchClient client) {
         this.client = client;
@@ -30,15 +35,22 @@ public class SuggestRepositoryImpl implements SuggestRepository {
         return (o == null) ? null : String.valueOf(o);
     }
 
+
+
     @Override
     public List<AutocompleteResponse> suggest(String query, int limit) {
         try {
             if (query == null || query.isBlank()) return List.of();
 
-            final String queryText = query.trim();
-            final int size = Math.max(1, limit);
 
-            // 1) completion suggest (제목/장소)
+            final String queryText = query.trim();// 앞뒤 공백 제거
+            final int size = Math.max(1, limit);// 최소 1개 이상은 요청
+
+
+            // 1단계: completion suggester로 "제목"과 "장소"에서 자동완성 후보 뽑기
+                 // completion 필드는 인덱스 만들 때 따로 지정해둔 eventTitle_suggest / placeName_suggest
+                 // 철자 조금 틀려도 잡아주게 fuzziness = AUTO
+
             SearchResponse<Map<String, Object>> completionResponse = client.search(s -> s
                             .index(IndexNames.EVENTS)
                             .size(0)
@@ -63,9 +75,11 @@ public class SuggestRepositoryImpl implements SuggestRepository {
                     (Class<Map<String, Object>>) (Class<?>) Map.class
             );
 
+            //중복 제거용(입력값이 제목/장소 둘 다에서 나올 수 있으므로)
             LinkedHashSet<String> dedup = new LinkedHashSet<>();
             List<AutocompleteResponse> results = new ArrayList<>();
 
+            // 결과에서 실제 텍스트만 뽑아서 담기
             Map<String, List<Suggestion<Map<String, Object>>>> suggestionsMap = completionResponse.suggest();
             if (suggestionsMap != null) {
                 for (String key : new String[]{SG_TITLE, SG_PLACE}) {
@@ -73,7 +87,7 @@ public class SuggestRepositoryImpl implements SuggestRepository {
                     if (suggestionList == null || suggestionList.isEmpty()) continue;
 
                     suggestionList.get(0).completion().options().forEach(option -> {
-                        String optionText = option.text();
+                        String optionText = option.text();// 추천 텍스트
                         if (optionText != null && dedup.add(optionText)) {
                             results.add(new AutocompleteResponse(optionText, 0L));
                         }
@@ -81,10 +95,14 @@ public class SuggestRepositoryImpl implements SuggestRepository {
                 }
             }
 
-            // 2) 보충: prefix 검색(eventTitle / placeName / placeAddress)
+
+
+            // 2단계: 추천 개수가 모자라면, 원문필드에서 앞부분 일치로 보충
             if (results.size() < size) {
                 int remain = size - results.size();
 
+                // eventTitle / placeName / placeAddress 세 필드에서
+                // 앞 부분이 이 글자로 시작하는 문서 찾기
                 SearchResponse<Map<String, Object>> prefixResponse = client.search(s -> s
                                 .index(IndexNames.EVENTS)
                                 .size(Math.max(remain, 1))
@@ -105,11 +123,18 @@ public class SuggestRepositoryImpl implements SuggestRepository {
                         (Class<Map<String, Object>>) (Class<?>) Map.class
                 );
 
+                // 어떤 필드를 최우선으로 자동완성 후보로 쓸지 순서 정의
                 List<String> candidateFields = List.of(
                         IndexNames.FIELD_EVENT_TITLE,
                         IndexNames.FIELD_PLACE_NAME,
                         IndexNames.FIELD_PLACE_ADDR
                 );
+
+                // 검색된 문서들에서 자동완성 후보 텍스트 고르는 규칙
+                    // 입력으로 시작하는 값이 있으면 그걸 채택
+                    // 없으면 포함하는 값 중 하나
+                    // 그래도 없으면 타이틀-> 장소-> 주소 순서로 첫 값
+                    // 이미 담은 텍스트는 또 안 담음
 
                 prefixResponse.hits().hits().forEach(hit -> {
                     Map<String, Object> sourceMap = hit.source();
@@ -156,6 +181,7 @@ public class SuggestRepositoryImpl implements SuggestRepository {
                 });
             }
 
+            // 요청 개수보다 많이 모였으면 앞에서 size개만 잘라서 반환
             return results.size() > size ? results.subList(0, size) : results;
         } catch (IOException e) {
             throw new RuntimeException("Elasticsearch suggest failed", e);

--- a/src/main/java/com/example/momentix/domain/search/impl/SuggestRepositoryImpl.java
+++ b/src/main/java/com/example/momentix/domain/search/impl/SuggestRepositoryImpl.java
@@ -1,0 +1,164 @@
+package com.example.momentix.domain.search.impl;
+
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Suggestion;
+import com.example.momentix.domain.common.elasticsearch.IndexNames;
+import com.example.momentix.domain.search.dto.AutocompleteResponse;
+import com.example.momentix.domain.search.repository.SuggestRepository;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.*;
+
+//자동완성 구현  (completion 우선, 부족 시 prefix 보충)
+//completion(자동완성 미리 넣어둔 사전)
+//prefix(원본 텍스트에서 대로 시작하는 필드 직접 검색)
+@Repository
+public class SuggestRepositoryImpl implements SuggestRepository {
+    private static final String SG_TITLE = "title-suggest";
+    private static final String SG_PLACE = "place-suggest";
+
+    private final ElasticsearchClient client;
+
+    public SuggestRepositoryImpl(ElasticsearchClient client) {
+        this.client = client;
+    }
+
+    private static String asString(Object o) {
+        return (o == null) ? null : String.valueOf(o);
+    }
+
+    @Override
+    public List<AutocompleteResponse> suggest(String query, int limit) {
+        try {
+            if (query == null || query.isBlank()) return List.of();
+
+            final String queryText = query.trim();
+            final int size = Math.max(1, limit);
+
+            // 1) completion suggest (제목/장소)
+            SearchResponse<Map<String, Object>> completionResponse = client.search(s -> s
+                            .index(IndexNames.EVENTS)
+                            .size(0)
+                            .suggest(suggestBuilder -> suggestBuilder
+                                    .suggesters(SG_TITLE, st -> st
+                                            .prefix(queryText)
+                                            .completion(c -> c
+                                                    .field(IndexNames.FIELD_EVENT_TITLE_SUGGEST)
+                                                    .size(size)
+                                                    .fuzzy(f -> f.fuzziness("AUTO"))
+                                            )
+                                    )
+                                    .suggesters(SG_PLACE, st -> st
+                                            .prefix(queryText)
+                                            .completion(c -> c
+                                                    .field(IndexNames.FIELD_PLACE_NAME_SUGGEST)
+                                                    .size(size)
+                                                    .fuzzy(f -> f.fuzziness("AUTO"))
+                                            )
+                                    )
+                            ),
+                    (Class<Map<String, Object>>) (Class<?>) Map.class
+            );
+
+            LinkedHashSet<String> dedup = new LinkedHashSet<>();
+            List<AutocompleteResponse> results = new ArrayList<>();
+
+            Map<String, List<Suggestion<Map<String, Object>>>> suggestionsMap = completionResponse.suggest();
+            if (suggestionsMap != null) {
+                for (String key : new String[]{SG_TITLE, SG_PLACE}) {
+                    List<Suggestion<Map<String, Object>>> suggestionList = suggestionsMap.get(key);
+                    if (suggestionList == null || suggestionList.isEmpty()) continue;
+
+                    suggestionList.get(0).completion().options().forEach(option -> {
+                        String optionText = option.text();
+                        if (optionText != null && dedup.add(optionText)) {
+                            results.add(new AutocompleteResponse(optionText, 0L));
+                        }
+                    });
+                }
+            }
+
+            // 2) 보충: prefix 검색(eventTitle / placeName / placeAddress)
+            if (results.size() < size) {
+                int remain = size - results.size();
+
+                SearchResponse<Map<String, Object>> prefixResponse = client.search(s -> s
+                                .index(IndexNames.EVENTS)
+                                .size(Math.max(remain, 1))
+                                .query(qb -> qb.bool(b -> b
+                                        .should(sh -> sh.matchPhrasePrefix(m -> m
+                                                .field(IndexNames.FIELD_EVENT_TITLE)
+                                                .query(queryText)
+                                        ))
+                                        .should(sh -> sh.matchPhrasePrefix(m -> m
+                                                .field(IndexNames.FIELD_PLACE_NAME)
+                                                .query(queryText)
+                                        ))
+                                        .should(sh -> sh.matchPhrasePrefix(m -> m
+                                                .field(IndexNames.FIELD_PLACE_ADDR)
+                                                .query(queryText)
+                                        ))
+                                )),
+                        (Class<Map<String, Object>>) (Class<?>) Map.class
+                );
+
+                List<String> candidateFields = List.of(
+                        IndexNames.FIELD_EVENT_TITLE,
+                        IndexNames.FIELD_PLACE_NAME,
+                        IndexNames.FIELD_PLACE_ADDR
+                );
+
+                prefixResponse.hits().hits().forEach(hit -> {
+                    Map<String, Object> sourceMap = hit.source();
+                    if (sourceMap == null) return;
+
+                    String candidate = null;
+
+                    // (1) 접두사 일치 우선
+                    for (String field : candidateFields) {
+                        String fieldValue = asString(sourceMap.get(field));
+                        if (fieldValue == null) continue;
+                        String normalized = fieldValue.trim();
+                        if (!normalized.isBlank() && normalized.startsWith(queryText)) {
+                            candidate = normalized;
+                            break;
+                        }
+                    }
+
+                    // (2) 포함 일치(보조)
+                    if (candidate == null) {
+                        for (String field : candidateFields) {
+                            String fieldValue = asString(sourceMap.get(field));
+                            if (fieldValue == null) continue;
+                            String normalized = fieldValue.trim();
+                            if (!normalized.isBlank() && normalized.contains(queryText)) {
+                                candidate = normalized;
+                                break;
+                            }
+                        }
+                    }
+
+                    // (3) 최종 폴백: 타이틀 → 장소 → 주소
+                    if (candidate == null) {
+                        candidate = Optional.ofNullable(asString(sourceMap.get(IndexNames.FIELD_EVENT_TITLE)))
+                                .orElse(Optional.ofNullable(asString(sourceMap.get(IndexNames.FIELD_PLACE_NAME)))
+                                        .orElse(asString(sourceMap.get(IndexNames.FIELD_PLACE_ADDR))));
+                        if (candidate != null) candidate = candidate.trim();
+                    }
+
+                    // (4) 중복 없이 한 번만 추가
+                    if (candidate != null && !candidate.isBlank() && dedup.add(candidate)) {
+                        results.add(new AutocompleteResponse(candidate, 0L));
+                    }
+                });
+            }
+
+            return results.size() > size ? results.subList(0, size) : results;
+        } catch (IOException e) {
+            throw new RuntimeException("Elasticsearch suggest failed", e);
+        }
+    }
+}

--- a/src/main/java/com/example/momentix/domain/search/repository/AnalyticsRepository.java
+++ b/src/main/java/com/example/momentix/domain/search/repository/AnalyticsRepository.java
@@ -7,11 +7,16 @@ import com.example.momentix.domain.search.dto.SearchLogDoc;
 import java.util.List;
 
 
-//집계 호출
+//검색 로그를 바탕으로 한 통계/집계 기능
+// 구현체가 실제로 엘라스틱서치에 요청을 날림
 public interface AnalyticsRepository {
+
+    // 최근 N 시간 동안 1시간 단위로 검색이 몇 건 있었는지
     List<HourlyCountBucket> countPerHour(int hours) ;
+
+    // 최근 N 시간 동안 가장 많이 검색된 단어 
     List<AutocompleteResponse> popularQueries(int hours, int size) ;
 
-    //검색 로그
+    // 검색할 때 남기는 로그 한 건을 저장
     void indexSearchLog(SearchLogDoc doc);
 }

--- a/src/main/java/com/example/momentix/domain/search/repository/AnalyticsRepository.java
+++ b/src/main/java/com/example/momentix/domain/search/repository/AnalyticsRepository.java
@@ -1,0 +1,5 @@
+package com.example.momentix.domain.search.repository;
+
+//집계 호출
+public class AnalyticsRepository {
+}

--- a/src/main/java/com/example/momentix/domain/search/repository/AnalyticsRepository.java
+++ b/src/main/java/com/example/momentix/domain/search/repository/AnalyticsRepository.java
@@ -1,5 +1,17 @@
 package com.example.momentix.domain.search.repository;
 
+import com.example.momentix.domain.search.dto.AutocompleteResponse;
+import com.example.momentix.domain.search.dto.HourlyCountBucket;
+import com.example.momentix.domain.search.dto.SearchLogDoc;
+
+import java.util.List;
+
+
 //집계 호출
-public class AnalyticsRepository {
+public interface AnalyticsRepository {
+    List<HourlyCountBucket> countPerHour(int hours) ;
+    List<AutocompleteResponse> popularQueries(int hours, int size) ;
+
+    //검색 로그
+    void indexSearchLog(SearchLogDoc doc);
 }

--- a/src/main/java/com/example/momentix/domain/search/repository/SuggestRepository.java
+++ b/src/main/java/com/example/momentix/domain/search/repository/SuggestRepository.java
@@ -1,5 +1,12 @@
 package com.example.momentix.domain.search.repository;
 
+import com.example.momentix.domain.search.dto.AutocompleteResponse;
+
+import java.util.List;
+
+
 //인기순 자동완성, completion suggester 호출
-public class SuggestRepository {
+public interface SuggestRepository{
+
+    List<AutocompleteResponse> suggest(String query, int limit) ;
 }

--- a/src/main/java/com/example/momentix/domain/search/repository/SuggestRepository.java
+++ b/src/main/java/com/example/momentix/domain/search/repository/SuggestRepository.java
@@ -5,8 +5,9 @@ import com.example.momentix.domain.search.dto.AutocompleteResponse;
 import java.util.List;
 
 
-//인기순 자동완성, completion suggester 호출
+//자동 완성 기능
 public interface SuggestRepository{
 
+    // 입력 글자(query) 기준으로 자동와성 후보 최대 limit개
     List<AutocompleteResponse> suggest(String query, int limit) ;
 }

--- a/src/main/java/com/example/momentix/domain/search/repository/SuggestRepository.java
+++ b/src/main/java/com/example/momentix/domain/search/repository/SuggestRepository.java
@@ -1,0 +1,5 @@
+package com.example.momentix.domain.search.repository;
+
+//인기순 자동완성, completion suggester 호출
+public class SuggestRepository {
+}

--- a/src/main/java/com/example/momentix/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/momentix/domain/search/service/SearchService.java
@@ -1,23 +1,80 @@
 package com.example.momentix.domain.search.service;
 
+import com.example.momentix.domain.common.elasticsearch.IndexNames;
 import com.example.momentix.domain.events.repository.EventsRepository;
-import com.example.momentix.domain.search.dto.SearchRequestDto;
-import com.example.momentix.domain.search.dto.SearchResponseDto;
-import lombok.RequiredArgsConstructor;
+import com.example.momentix.domain.search.dto.*;
+import com.example.momentix.domain.search.repository.AnalyticsRepository;
+import com.example.momentix.domain.search.repository.SuggestRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.util.List;
+
 @Service
-@RequiredArgsConstructor
 public class SearchService {
     private final EventsRepository eventsRepository;
+
+
+    private final SuggestRepository suggestRepository;
+    private final AnalyticsRepository analyticsRepository;
+
+    public SearchService(
+            EventsRepository eventsRepository,
+            SuggestRepository suggestRepository,
+            AnalyticsRepository analyticsRepository
+    ) {
+        this.eventsRepository = eventsRepository;
+        this.suggestRepository = suggestRepository;
+        this.analyticsRepository = analyticsRepository;
+    }
 
     @Transactional(readOnly = true)
     public Page<SearchResponseDto> searchEvent(SearchRequestDto searchRequestdto, Pageable pageable) {
         return eventsRepository.searchEventByParam(searchRequestdto, pageable);
     }
 
-    //
+    //엘라스틱서치
+    @Transactional(readOnly = true)
+    public List<AutocompleteResponse> autocomplete(String input, int size) {
+        int limit = size > 0 ? size : IndexNames.DEFAULT_SUGGEST_SIZE;
+        return suggestRepository.suggest(input, limit);
+    }
+
+    @Transactional(readOnly = true)
+    public List<HourlyCountBucket> hourlyCounts(int hours) {
+        return analyticsRepository.countPerHour(hours);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AutocompleteResponse> popularQueries(int hours, int size) {
+        return analyticsRepository.popularQueries(hours, size);
+    }
+
+
+    // 인기 검색어 로그 집계
+    @Async
+    public void logSearchAsync(SearchRequestDto req, String userId, String ip) {
+        if (req == null || req.getQuery() == null || req.getQuery().isBlank())
+            return;
+
+        String category = (req.getEventCategory() == null) ? null : req.getEventCategory().name();
+        String start = (req.getSearchStartDate() == null) ? null : req.getSearchStartDate().toString();
+        String end = (req.getSearchEndDate() == null) ? null : req.getSearchEndDate().toString();
+
+        SearchLogDoc doc = new SearchLogDoc(
+                req.getQuery(),
+                category,
+                start,
+                end,
+                userId,
+                ip,
+                Instant.now().toEpochMilli()
+        );
+
+        analyticsRepository.indexSearchLog(doc);
+    }
 }

--- a/src/main/java/com/example/momentix/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/momentix/domain/search/service/SearchService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Service
@@ -21,6 +23,11 @@ public class SearchService {
 
     private final SuggestRepository suggestRepository;
     private final AnalyticsRepository analyticsRepository;
+
+    // 인기 검색어 캐시 (1시간 단위 랭킹 고정 노출)
+    private volatile List<AutocompleteResponse> cachedPopular = null;
+    private volatile long popularCacheExpireAtMillis = 0L; // 캐시 만료 시각(밀리초)
+
 
     public SearchService(
             EventsRepository eventsRepository,
@@ -38,12 +45,15 @@ public class SearchService {
     }
 
     //엘라스틱서치
+    
+    // 자동완성
     @Transactional(readOnly = true)
     public List<AutocompleteResponse> autocomplete(String input, int size) {
         int limit = size > 0 ? size : IndexNames.DEFAULT_SUGGEST_SIZE;
         return suggestRepository.suggest(input, limit);
     }
 
+    // 시간대별 검색 수 집계
     @Transactional(readOnly = true)
     public List<HourlyCountBucket> hourlyCounts(int hours) {
         return analyticsRepository.countPerHour(hours);
@@ -51,15 +61,37 @@ public class SearchService {
 
     @Transactional(readOnly = true)
     public List<AutocompleteResponse> popularQueries(int hours, int size) {
-        return analyticsRepository.popularQueries(hours, size);
+        final int topN = (size > 0) ? size : 10;
+        final long now = System.currentTimeMillis();
+
+        // 1) 캐시 유효하면 그대로 반환 (ES 재조회 막기)
+        List<AutocompleteResponse> local = cachedPopular; // volatile 읽기
+        if (local != null && now < popularCacheExpireAtMillis) {
+            return (local.size() > topN) ? local.subList(0, topN) : local;
+        }
+
+        // 2) 캐시 만료/미존재 → 동기화 블록에서 한 번만 갱신
+        synchronized (this) {
+            // 들어오는 동안 이미 갱신됐을 수 있으니 재확인
+            if (cachedPopular != null && System.currentTimeMillis() < popularCacheExpireAtMillis) {
+                return (cachedPopular.size() > topN) ? cachedPopular.subList(0, topN) : cachedPopular;
+            }
+
+            // 기획 고정: 최근 1시간 집계만 사용
+            List<AutocompleteResponse> fresh = analyticsRepository.popularQueries(1, topN);
+
+            // 캐시에 저장 + 만료시각을 다음 정각으로 설정 (랭킹 1시간 단위 고정 노출)
+            cachedPopular = (fresh == null) ? List.of() : fresh;
+            popularCacheExpireAtMillis = nextTopOfHourMillis();
+
+            return cachedPopular;
+        }
     }
 
-
-    // 인기 검색어 로그 집계
+    // 검색 로그 비동기 적재 (인기검색어 집계의 원천 데이터)
     @Async
     public void logSearchAsync(SearchRequestDto req, String userId, String ip) {
-        if (req == null || req.getQuery() == null || req.getQuery().isBlank())
-            return;
+        if (req == null || req.getQuery() == null || req.getQuery().isBlank()) return;
 
         String category = (req.getEventCategory() == null) ? null : req.getEventCategory().name();
         String start = (req.getSearchStartDate() == null) ? null : req.getSearchStartDate().toString();
@@ -74,7 +106,14 @@ public class SearchService {
                 ip,
                 Instant.now().toEpochMilli()
         );
-
         analyticsRepository.indexSearchLog(doc);
+    }
+
+    // 다음 정각(Asia/Seoul)까지 → 랭킹을 딱 1시간 간격으로 갱신
+    private long nextTopOfHourMillis() {
+        ZonedDateTime nextHour = ZonedDateTime.now(ZoneId.of(IndexNames.TIME_ZONE_SEOUL))
+                .withMinute(0).withSecond(0).withNano(0)
+                .plusHours(1);
+        return nextHour.toInstant().toEpochMilli();
     }
 }

--- a/src/main/java/com/example/momentix/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/momentix/domain/search/service/SearchService.java
@@ -18,4 +18,6 @@ public class SearchService {
     public Page<SearchResponseDto> searchEvent(SearchRequestDto searchRequestdto, Pageable pageable) {
         return eventsRepository.searchEventByParam(searchRequestdto, pageable);
     }
+
+    //
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,3 +68,7 @@ spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true
+
+# elasticsSearch
+elasticsearch.url=${ELASTICSEARCH_URL}
+elasticsearch.api-key=${ELASTIC_API_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,3 +72,4 @@ spring.mail.properties.mail.smtp.starttls.required=true
 # elasticsSearch
 elasticsearch.url=${ELASTICSEARCH_URL}
 elasticsearch.apikey=${ELASTIC_API_KEY}
+search.bootstrap.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -71,4 +71,4 @@ spring.mail.properties.mail.smtp.starttls.required=true
 
 # elasticsSearch
 elasticsearch.url=${ELASTICSEARCH_URL}
-elasticsearch.api-key=${ELASTIC_API_KEY}
+elasticsearch.apikey=${ELASTIC_API_KEY}


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

제가 사용한 엘라스틱 방식은 
completion suggester 입니다.

### 비교표

| 개념            | **`completion suggester` ✅**                                                                                                   | `search_as_you_type`                                                                                                                        |
| ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **매핑 타입**     | `completion` 전용 필드를 둠 → 자동완성만을 위해 설계된 타입. <br>[공식 문서](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/completion) | `search_as_you_type` 필드를 둠 → 원래는 일반 텍스트 검색을 쉽게 하려는 용도. <br>[공식 문서](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/search-as-you-type) |
| **검색 동작 방식**  | 사용자가 입력한 prefix(앞부분)에 대해 \*\*미리 만들어둔 자동완성 사전(FST 구조)\*\*에서 즉시 결과 반환 → 속도가 매우 빠름. 대용량 데이터에서도 안정적.                                        | 입력할 때마다 여러 하위 필드(`_2gram`, `_3gram`, `_index_prefix`)를 직접 검색 → 데이터 많아지면 **쿼리 비용 커지고 느려질 수 있음**.                                                              |
| **데이터 저장 방식** | 공연명, 장소명 같은 자동완성 후보를 미리 사전에 저장. 오타 보정(fuzzy) 옵션까지 지원됨.                                                                                  | 문서 색인 시 자동으로 여러 ngram/prefix 필드 생성. 별도 후보 사전은 필요 없음. 하지만 인덱스 크기 커짐.                                                                                          |
| **재색인 필요 여부** | 새 데이터가 들어오면 자동완성 필드도 색인해야 함 → **재색인 필요**. 하지만 공연/장소 데이터는 자주 안 바뀌므로 부담 없음.                                                               | 새 문서 들어오면 자동 반영 → 재색인 불필요. 하지만 우리처럼 “고정된 공연/장소명”에는 굳이 필요 없는 장점.                                                                                              |
| **성능·유지보수**   | 조회 성능 최상. 자동완성만 하면 됨. 대신 메모리와 색인 비용이 조금 있음. 그러나 우리 도메인(공연 데이터 규모)에서는 큰 문제 아님.                                                           | 인덱스 크기가 커지고 analyzer/tokenizer 관리 복잡. 운영/튜닝 난이도 있음.                                                                                                          |
| **적합한 경우**    | 공연명, 장소명, 카테고리처럼 **등록되면 잘 안 바뀌는 짧은 문자열**. 입력할 때 바로 추천 떠야 하는 경우. → **우리 서비스에 딱 맞음**                                                     | 블로그 글, 뉴스 기사처럼 길고 자주 바뀌는 텍스트. 중간 단어(infix) 검색까지 필요할 때. 우리 서비스에는 불필요.                                                                                         |




### Completion suggester 사용한 이유

- 빠르다 → 미리 준비된 자동완성 사전에서 바로 꺼내오기 때문에 대용량에서도 속도 안정적

- 전용 기능이다 → 자동완성만을 위해 설계된 타입이라 단순하고 목적에 딱 맞음

- 오타 보정 기본 지원 → 사용성(UX) 개선에 도움

- 재색인 단점도 문제 없음 → 공연/장소 데이터는 자주 바뀌지 않아서 실제 부담이 적음



---

### 자동 완성 기능 구현
공연명, 장소명 같은 고정 데이터를 필드에 색인해 두고 사용자가 입력한 앞 부분에 맞춰 미리 준비된 자동 완성 사전에서 즉시 추천을 꺼내오는 방식

### 인기 검색어 구현
사용자 검색 로그를 별도 인덱스에 기록하고
집계 기능을 이용하여 1시간 단위로 랭킹 검색어 확인 가능하도록 구현 

---

## 추가 작업
### 자동 재색인 
스트링부트가 한 번 실행되면 MySQL 매핑 후 엘라스틱서치 인덱스에 자동으로 올라가 집니다.

---
슬랙 "도메인"에 .env 코드 넣어두었습니다.




## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
