### PR TITLE
payment 동시성 이슈 고려하여 개선 완료

### DIFF
--- a/src/main/java/com/example/momentix/domain/paymenthistory/dto/PaymentCreateRequest.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/dto/PaymentCreateRequest.java
@@ -13,22 +13,41 @@ public class PaymentCreateRequest {
     private final String payer;
     private final String paymentMethod;
     private final BigDecimal paymentPrice;
+    private final String idempotencyKey;// 같은 요청 재전송/더블클릭/네트워크 재시도로도 중복 생성방지용도
 
     @JsonCreator
     public PaymentCreateRequest(
             @JsonProperty("reservationId") Long reservationId,
             @JsonProperty("payer") String payer,
             @JsonProperty("paymentMethod") String paymentMethod,
-            @JsonProperty("paymentPrice") BigDecimal paymentPrice
+            @JsonProperty("paymentPrice") BigDecimal paymentPrice,
+            @JsonProperty("idempotencyKey") String idempotencyKey
     ) {
         this.reservationId = reservationId;
         this.payer = payer;
         this.paymentMethod = paymentMethod;
         this.paymentPrice = paymentPrice;
+        this.idempotencyKey = idempotencyKey;
     }
 
-    public Long getReservationId(){return reservationId;}
-    public String getPayer(){return payer;}
-    public String getPaymentMethod(){return paymentMethod;}
-    public BigDecimal getPaymentPrice() { return paymentPrice; }
+    public Long getReservationId() {
+        return reservationId;
+    }
+
+    public String getPayer() {
+        return payer;
+    }
+
+    public String getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public BigDecimal getPaymentPrice() {
+        return paymentPrice;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
 }

--- a/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
@@ -6,10 +6,7 @@ import lombok.Getter;
 
 import java.math.BigDecimal;
 
-// 낙관적 락으로 업데이트 충돌 방지
-// idempotencyKey: 유니크(같은 요청 중복 생성 차단)
-// (reservationId, paymentStatusType) UNIQUE: 동일 예약에서 같은 상태 중복 생성 차단
-// 예약 1건에 SUCCESS 1건
+//중복 결제 요청을 방지하는 멱등 제어(Idempotency) 방식
 @Table(
         name = "payment_history",
         uniqueConstraints = {

--- a/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
@@ -6,7 +6,17 @@ import lombok.Getter;
 
 import java.math.BigDecimal;
 
-@Table(name = "payment_history")
+// 낙관적 락으로 업데이트 충돌 방지
+// idempotencyKey: 유니크(같은 요청 중복 생성 차단)
+// (reservationId, paymentStatusType) UNIQUE: 동일 예약에서 같은 상태 중복 생성 차단
+// 예약 1건에 SUCCESS 1건
+@Table(
+        name = "payment_history",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "ux_payment_idempotency", columnNames = {"idempotency_key"}),
+                @UniqueConstraint(name = "ux_reservation_status", columnNames = {"reservation_id", "payment_status"})
+        }
+)
 @Entity
 @Getter
 public class PaymentHistory extends TimeStamped {
@@ -15,8 +25,12 @@ public class PaymentHistory extends TimeStamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long paymentHistoryId;
 
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     // 예약 ID, 티켓발급 시 필요한 키
-    @Column(nullable = false)
+    @Column(name = "reservation_id", nullable = false)
     private Long reservationId;
 
     //결제자
@@ -28,7 +42,7 @@ public class PaymentHistory extends TimeStamped {
     private String paymentMethod;
 
     //결제금액
-    @Column(name = "payment_price")
+    @Column(name = "payment_price", nullable = false)
     private BigDecimal paymentPrice;
 
     //결제 상태
@@ -36,29 +50,66 @@ public class PaymentHistory extends TimeStamped {
     @Column(name = "payment_status")
     private PaymentStatusType paymentStatusType;
 
+    // 중복 생성 차단
+    @Column(name = "idempotency_key", nullable = false, length = 100)
+    private String idempotencyKey;
+
     // 매개변수 없는 생성자 = No-Args-Constructor
-   protected PaymentHistory(){
+    protected PaymentHistory() {
     }
 
-    public static PaymentHistory create(Long reservationId, String payer, String method, BigDecimal price){
+    public static PaymentHistory create(Long reservationId, String payer, String method, BigDecimal price, String idempotencyKey) {
         PaymentHistory paymentHistory = new PaymentHistory();
         paymentHistory.reservationId = reservationId;
         paymentHistory.payer = payer;
         paymentHistory.paymentMethod = method;
         paymentHistory.paymentPrice = price == null ? BigDecimal.ZERO : price;
+        paymentHistory.idempotencyKey = idempotencyKey;
         paymentHistory.paymentStatusType = PaymentStatusType.PENDING;
         return paymentHistory;
     }
 
+    public void markSuccess() {
+        this.paymentStatusType = PaymentStatusType.SUCCESS;
+    }
 
-    public void markSuccess() { this.paymentStatusType = PaymentStatusType.SUCCESS; }
-    public void markFailed()  { this.paymentStatusType = PaymentStatusType.FAILED; }
-    public void markCancel()  { this.paymentStatusType = PaymentStatusType.CANCEL; }
+    public void markFailed() {
+        this.paymentStatusType = PaymentStatusType.FAILED;
+    }
 
-    public Long getPaymentHistoryId() { return paymentHistoryId; }
-    public Long getReservationId() { return reservationId; }
-    public String getPayer() { return payer; }
-    public String getPaymentMethod() { return paymentMethod; }
-    public BigDecimal getPaymentPrice() { return paymentPrice; }
-    public PaymentStatusType getPaymentStatusType() { return paymentStatusType; }
+    public void markCancel() {
+        this.paymentStatusType = PaymentStatusType.CANCEL;
+    }
+
+    public Long getPaymentHistoryId() {
+        return paymentHistoryId;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public Long getReservationId() {
+        return reservationId;
+    }
+
+    public String getPayer() {
+        return payer;
+    }
+
+    public String getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public BigDecimal getPaymentPrice() {
+        return paymentPrice;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public PaymentStatusType getPaymentStatusType() {
+        return paymentStatusType;
+    }
 }

--- a/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
@@ -27,10 +27,6 @@ public class PaymentHistory extends TimeStamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long paymentHistoryId;
 
-    @Version
-    @Column(name = "version")
-    private Long version;
-
     // 예약 ID, 티켓발급 시 필요한 키
     @Column(name = "reservation_id", nullable = false)
     private Long reservationId;
@@ -85,10 +81,6 @@ public class PaymentHistory extends TimeStamped {
 
     public Long getPaymentHistoryId() {
         return paymentHistoryId;
-    }
-
-    public Long getVersion() {
-        return version;
     }
 
     public Long getReservationId() {

--- a/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
@@ -6,10 +6,7 @@ import lombok.Getter;
 
 import java.math.BigDecimal;
 
-// 낙관적 락으로 업데이트 충돌 방지
-// idempotencyKey: 유니크(같은 요청 중복 생성 차단)
-// (reservationId, paymentStatusType) UNIQUE: 동일 예약에서 같은 상태 중복 생성 차단
-// 예약 1건에 SUCCESS 1건
+//중복 결제 요청을 방지하는 멱등 제어(Idempotency) 방식
 @Table(
         name = "payment_history",
         uniqueConstraints = {
@@ -56,7 +53,8 @@ public class PaymentHistory extends TimeStamped {
     protected PaymentHistory() {
     }
 
-    public static PaymentHistory create(Long reservationId, String payer, String method, BigDecimal price, String idempotencyKey) {
+    public static PaymentHistory create(Long reservationId, String payer, String method, BigDecimal price,
+                                        String idempotencyKey) {
         PaymentHistory paymentHistory = new PaymentHistory();
         paymentHistory.reservationId = reservationId;
         paymentHistory.payer = payer;

--- a/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/entity/PaymentHistory.java
@@ -13,8 +13,10 @@ import java.math.BigDecimal;
 @Table(
         name = "payment_history",
         uniqueConstraints = {
-                @UniqueConstraint(name = "ux_payment_idempotency", columnNames = {"idempotency_key"}),
-                @UniqueConstraint(name = "ux_reservation_status", columnNames = {"reservation_id", "payment_status"})
+                @UniqueConstraint(
+                        name = "ux_reservation_id_idempotency",
+                        columnNames = {"reservation_id", "idempotency_key"}
+                )
         }
 )
 @Entity

--- a/src/main/java/com/example/momentix/domain/paymenthistory/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/repository/PaymentHistoryRepository.java
@@ -15,11 +15,11 @@ public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, 
 
     // 상태 유니크 제약으로 DB가 막고, 조회는 참고용으로만 사용
     @Query("""
-           select (count(paymentHistory) > 0)
-             from PaymentHistory paymentHistory
-            where paymentHistory.reservationId = :reservationId
-              and paymentHistory.paymentStatusType = com.example.momentix.domain.paymenthistory.entity.PaymentStatusType.PENDING
-           """)
+            select (count(paymentHistory) > 0)
+              from PaymentHistory paymentHistory
+             where paymentHistory.reservationId = :reservationId
+               and paymentHistory.paymentStatusType = com.example.momentix.domain.paymenthistory.entity.PaymentStatusType.PENDING
+            """)
     boolean existsPendingByReservation(@Param("reservationId") Long reservationId);
 
     Optional<PaymentHistory> findByReservationIdAndIdempotencyKey(Long reservationId, String key);

--- a/src/main/java/com/example/momentix/domain/paymenthistory/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/repository/PaymentHistoryRepository.java
@@ -22,10 +22,10 @@ public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, 
            """)
     boolean existsPendingByReservation(@Param("reservationId") Long reservationId);
 
-    Optional<PaymentHistory> findByIdempotencyKey(String idempotencyKey);
+    Optional<PaymentHistory> findByReservationIdAndIdempotencyKey(Long reservationId, String key);
 
-    // 비관적 락으로 결제 레코드 선점
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select paymentHistory from PaymentHistory paymentHistory where paymentHistory.paymentHistoryId = :id")
+    @Query("select ph from PaymentHistory ph where ph.paymentHistoryId = :id")
     Optional<PaymentHistory> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/example/momentix/domain/paymenthistory/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/repository/PaymentHistoryRepository.java
@@ -1,14 +1,19 @@
 package com.example.momentix.domain.paymenthistory.repository;
 
 import com.example.momentix.domain.paymenthistory.entity.PaymentHistory;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
 
+    // 상태 유니크 제약으로 DB가 막고, 조회는 참고용으로만 사용
     @Query("""
            select (count(paymentHistory) > 0)
              from PaymentHistory paymentHistory
@@ -16,4 +21,11 @@ public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, 
               and paymentHistory.paymentStatusType = com.example.momentix.domain.paymenthistory.entity.PaymentStatusType.PENDING
            """)
     boolean existsPendingByReservation(@Param("reservationId") Long reservationId);
+
+    Optional<PaymentHistory> findByIdempotencyKey(String idempotencyKey);
+
+    // 비관적 락으로 결제 레코드 선점
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select paymentHistory from PaymentHistory paymentHistory where paymentHistory.paymentHistoryId = :id")
+    Optional<PaymentHistory> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
@@ -44,51 +44,51 @@ public class PaymentHistoryService {
     //idempotencyKey가 같으면 항상 같은 결과를 반환(중복 생성 방지)
     //(reservationId, status) UNIQUE로 동일 예약의 PENDING 2개 생성 불가
     @Transactional
-    public PaymentResponse create(Long userId, PaymentCreateRequest req) {
-        if (req.getIdempotencyKey() == null || req.getIdempotencyKey().isBlank()) {
+    public PaymentResponse create(Long userId, PaymentCreateRequest paymentCreateRequest) {
+        if (paymentCreateRequest.getIdempotencyKey() == null || paymentCreateRequest.getIdempotencyKey().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "idempotencyKey가 필요합니다.");
         }
 
         // 1) 같은 예약 + 같은 멱등키면 기존 결과 그대로 반환
         Optional<PaymentHistory> existing =
                 paymentHistoryRepository.findByReservationIdAndIdempotencyKey(
-                        req.getReservationId(), req.getIdempotencyKey());
+                        paymentCreateRequest.getReservationId(), paymentCreateRequest.getIdempotencyKey());
 
         if (existing.isPresent()) {
-            Reservations r = reservationRepository.findById(existing.get().getReservationId())
+            Reservations reservations = reservationRepository.findById(existing.get().getReservationId())
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."));
-            if (!r.getUsers().getUserId().equals(userId)) {
+            if (!reservations.getUsers().getUserId().equals(userId)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
             }
             return PaymentResponse.of(existing.get());
         }
 
         // 2) 소유자 검증 (+ 필요시 예약 행 락)
-        Reservations r = reservationRepository.findByIdForUpdate(req.getReservationId())
-                .orElseGet(() -> reservationRepository.findById(req.getReservationId()).orElse(null));
-        if (r == null)
+        Reservations reservations = reservationRepository.findByIdForUpdate(paymentCreateRequest.getReservationId())
+                .orElseGet(() -> reservationRepository.findById(paymentCreateRequest.getReservationId()).orElse(null));
+        if (reservations == null)
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
-        if (!r.getUsers().getUserId().equals(userId)) {
+        if (!reservations.getUsers().getUserId().equals(userId)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
         }
 
         // 3) 생성 시도
-        PaymentHistory ph = PaymentHistory.create(
-                req.getReservationId(), req.getPayer(), req.getPaymentMethod(),
-                req.getPaymentPrice(), req.getIdempotencyKey());
+        PaymentHistory paymentHistory = PaymentHistory.create(
+                paymentCreateRequest.getReservationId(), paymentCreateRequest.getPayer(), paymentCreateRequest.getPaymentMethod(),
+                paymentCreateRequest.getPaymentPrice(), paymentCreateRequest.getIdempotencyKey());
 
         try {
-            paymentHistoryRepository.saveAndFlush(ph);
+            paymentHistoryRepository.saveAndFlush(paymentHistory);
         } catch (DataIntegrityViolationException e) {
             // 3-1) 더블클릭/재시도 등으로 이미 같은 (reservationId, idempotencyKey)가 들어간 경우 → 기존 반환
             Optional<PaymentHistory> dup =
                     paymentHistoryRepository.findByReservationIdAndIdempotencyKey(
-                            req.getReservationId(), req.getIdempotencyKey());
+                            paymentCreateRequest.getReservationId(), paymentCreateRequest.getIdempotencyKey());
             if (dup.isPresent())
                 return PaymentResponse.of(dup.get());
 
             // 3-2) 동일 예약에 PENDING이 이미 있는 경우 (상태 유니크 충돌)
-            if (paymentHistoryRepository.existsPendingByReservation(req.getReservationId())) {
+            if (paymentHistoryRepository.existsPendingByReservation(paymentCreateRequest.getReservationId())) {
                 throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 이 예약에 결제 대기 건이 존재합니다.");
             }
 
@@ -96,22 +96,22 @@ public class PaymentHistoryService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "결제 생성 중 제약조건 위반");
         }
 
-        return PaymentResponse.of(ph);
+        return PaymentResponse.of(paymentHistory);
     }
 
 
     // 결제 확정 (비관적 락 + 멱등)
     @Transactional
-    public PaymentResponse confirm(Long userId, Long paymentId, PaymentConfirmRequest req) {
+    public PaymentResponse confirm(Long userId, Long paymentId, PaymentConfirmRequest paymentConfirmRequest) {
         PaymentHistory paymentHistory = paymentHistoryRepository.findByIdForUpdate(paymentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "결제 내역이 없습니다."));
-        if (!paymentHistory.getReservationId().equals(req.getReservationId())) {
+        if (!paymentHistory.getReservationId().equals(paymentConfirmRequest.getReservationId())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "예약 정보가 결제와 일치하지 않습니다.");
         }
 
         //  예약 행 선점
-        Reservations reservations = reservationRepository.findByIdForUpdate(req.getReservationId())
-                .orElseGet(() -> reservationRepository.findById(req.getReservationId()).orElse(null));
+        Reservations reservations = reservationRepository.findByIdForUpdate(paymentConfirmRequest.getReservationId())
+                .orElseGet(() -> reservationRepository.findById(paymentConfirmRequest.getReservationId()).orElse(null));
         if (reservations == null)
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
         if (!reservations.getUsers().getUserId().equals(userId)) {
@@ -127,14 +127,14 @@ public class PaymentHistoryService {
         }
 
         // 같은 예약 티켓 중복 방지
-        if (ticketRepository.existsTicketByReservationId(req.getReservationId())) {
+        if (ticketRepository.existsTicketByReservationId(paymentConfirmRequest.getReservationId())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 이 예약으로 발급된 티켓이 있습니다.");
         }
 
         // 티켓 발급 & 링크
-        CreateTicketRequestDto ticketReq = new CreateTicketRequestDto();
-        ticketReq.setReservationId(req.getReservationId());
-        TicketResponseDto ticket = ticketService.createTicket(ticketReq);
+        CreateTicketRequestDto createTicketRequestDto = new CreateTicketRequestDto();
+        createTicketRequestDto.setReservationId(paymentConfirmRequest.getReservationId());
+        TicketResponseDto ticket = ticketService.createTicket(createTicketRequestDto);
 
         int updated = ticketRepository.linkPayment(ticket.getTicketId(), paymentHistory);
         if (updated == 0)

--- a/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
@@ -13,7 +13,8 @@ import com.example.momentix.domain.ticket.dto.response.TicketResponseDto;
 import com.example.momentix.domain.ticket.entity.Tickets;
 import com.example.momentix.domain.ticket.repository.TicketRepository;
 import com.example.momentix.domain.ticket.service.TicketService;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -40,91 +41,115 @@ public class PaymentHistoryService {
     }
 
     // 결제 생성(PENDING) - 상태만 관리하는 결제 + FK 주인(티켓)
+    //idempotencyKey가 같으면 항상 같은 결과를 반환(중복 생성 방지)
+    //(reservationId, status) UNIQUE로 동일 예약의 PENDING 2개 생성 불가
     @Transactional
     public PaymentResponse create(Long userId, PaymentCreateRequest paymentCreateRequest) {
-        Reservations r = reservationRepository.findById(paymentCreateRequest.getReservationId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다."));
-        if (!r.getUsers().getUserId().equals(userId)) {
-            throw new IllegalArgumentException("본인 예약이 아닙니다.");
+        if (paymentCreateRequest.getIdempotencyKey() == null || paymentCreateRequest.getIdempotencyKey().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "idempotencyKey가 필요합니다.");
         }
 
-        if (paymentHistoryRepository.existsPendingByReservation(paymentCreateRequest.getReservationId())) {
-            throw new IllegalStateException("이미 대기 중(PENDING)인 결제가 있습니다.");
+        // 1) 기존 생성 건 있으면 그대로 반환
+        Optional<PaymentHistory> existing = paymentHistoryRepository.findByIdempotencyKey(paymentCreateRequest.getIdempotencyKey());
+        if (existing.isPresent()) {
+            // 소유자/예약 검증만 추가 확인
+            Reservations reservations = reservationRepository.findById(existing.get().getReservationId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."));
+            if (!reservations.getUsers().getUserId().equals(userId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
+            }
+            return PaymentResponse.of(existing.get());
         }
 
+        // 2) 소유자 검증 (+ 필요시 예약 행에 락)
+        Reservations reservations = reservationRepository.findByIdForUpdate(paymentCreateRequest.getReservationId())
+                .orElseGet(() -> reservationRepository.findById(paymentCreateRequest.getReservationId()).orElse(null));
+        if (reservations == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
+        }
+        if (!reservations.getUsers().getUserId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
+        }
+
+        // 3) 생성 시도: 유니크 제약이 중복을 근본 차단
         PaymentHistory paymentHistory = PaymentHistory.create(
                 paymentCreateRequest.getReservationId(),
-                paymentCreateRequest.getPayer() == null ? "SELF" : paymentCreateRequest.getPayer(),
-                paymentCreateRequest.getPaymentMethod() == null ? "MOCK" : paymentCreateRequest.getPaymentMethod(),
-                paymentCreateRequest.getPaymentPrice()
+                paymentCreateRequest.getPayer(),
+                paymentCreateRequest.getPaymentMethod(),
+                paymentCreateRequest.getPaymentPrice(),
+                paymentCreateRequest.getIdempotencyKey()
         );
-        paymentHistoryRepository.save(paymentHistory);
+
+        try {
+            paymentHistoryRepository.saveAndFlush(paymentHistory); // 즉시 반영하여 유니크 위반을 조기에 감지
+        } catch (DataIntegrityViolationException e) {
+            // 3-1) 멱등 키 충돌 → 기존 엔티티 반환
+            Optional<PaymentHistory> dup = paymentHistoryRepository.findByIdempotencyKey(paymentCreateRequest.getIdempotencyKey());
+            if (dup.isPresent()) {
+                return PaymentResponse.of(dup.get());
+            }
+            // 3-2) 상태 유니크 충돌 (동일 예약의 PENDING 존재 등)
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 동일 예약에 해당 상태의 결제가 존재합니다.");
+        }
+
         return PaymentResponse.of(paymentHistory);
     }
 
-    // 결제 확정 (멱등)
+    // 결제 확정 (비관적 락 + 멱등)
     @Transactional
-    public PaymentResponse confirm(Long userId, Long paymentId, PaymentConfirmRequest paymentConfirmRequest) {
-        PaymentHistory paymentHistory = paymentHistoryRepository.findById(paymentId)
-                .orElseThrow(() -> new IllegalArgumentException("결제 내역이 없습니다."));
-
-        if (!paymentHistory.getReservationId().equals(paymentConfirmRequest.getReservationId())) {
-            throw new IllegalArgumentException("예약 정보가 결제와 일치하지 않습니다.");
+    public PaymentResponse confirm(Long userId, Long paymentId, PaymentConfirmRequest req) {
+        PaymentHistory paymentHistory = paymentHistoryRepository.findByIdForUpdate(paymentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "결제 내역이 없습니다."));
+        if (!paymentHistory.getReservationId().equals(req.getReservationId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "예약 정보가 결제와 일치하지 않습니다.");
         }
 
-        Reservations r = reservationRepository.findById(paymentConfirmRequest.getReservationId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다."));
-        if (!r.getUsers().getUserId().equals(userId)) {
-            throw new IllegalArgumentException("본인 예약이 아닙니다.");
+        //  예약 행 선점
+        Reservations reservations = reservationRepository.findByIdForUpdate(req.getReservationId())
+                .orElseGet(() -> reservationRepository.findById(req.getReservationId()).orElse(null));
+        if (reservations == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
+        if (!reservations.getUsers().getUserId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
         }
 
-        // 이미 이 paymentId로 링크된 티켓이 있으면 성공 간주
+        // 이미 링크된 티켓이면 멱등 성공
         Optional<Long> linkedTicketIdOpt = ticketRepository.findIdByPaymentId(paymentId);
         if (linkedTicketIdOpt.isPresent()) {
-            if (paymentHistory.getPaymentStatusType() == PaymentStatusType.PENDING) {
-                paymentHistory.markSuccess();
-            }
+            if (paymentHistory.getPaymentStatusType() == PaymentStatusType.PENDING) paymentHistory.markSuccess();
             return PaymentResponse.of(paymentHistory);
         }
 
-        // 같은 예약으로 이미 발급된 티켓이 있으면 중복 발급 방지
-        boolean ticketExists = ticketRepository.existsTicketByReservationId(paymentConfirmRequest.getReservationId());
-        if (ticketExists) {
-            throw new IllegalStateException("이미 이 예약으로 발급된 티켓이 있습니다.");
+        // 같은 예약 티켓 중복 방지
+        if (ticketRepository.existsTicketByReservationId(req.getReservationId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 이 예약으로 발급된 티켓이 있습니다.");
         }
 
-        // 티켓 발급
+        // 티켓 발급 & 링크
         CreateTicketRequestDto ticketReq = new CreateTicketRequestDto();
-        ticketReq.setReservationId(paymentConfirmRequest.getReservationId());
+        ticketReq.setReservationId(req.getReservationId());
         TicketResponseDto ticket = ticketService.createTicket(ticketReq);
 
-        // 티켓에 결제ID 링크 (FK 주인: 티켓)
         int updated = ticketRepository.linkPayment(ticket.getTicketId(), paymentHistory);
-        if (updated == 0) {
-            throw new IllegalStateException("티켓 결제 연결 실패");
-        }
+        if (updated == 0) throw new ResponseStatusException(HttpStatus.CONFLICT, "티켓 결제 연결 실패");
 
         paymentHistory.markSuccess();
         return PaymentResponse.of(paymentHistory);
     }
 
-
-    // 결제 취소
+    // 결제 취소 (비관적 락)
     @Transactional
     public PaymentResponse cancel(Long userId, Long paymentId) {
-        PaymentHistory paymentHistory = paymentHistoryRepository.findById(paymentId)
-                .orElseThrow(() -> new IllegalArgumentException("결제 내역이 없습니다."));
+        PaymentHistory paymentHistory = paymentHistoryRepository.findByIdForUpdate(paymentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "결제 내역이 없습니다."));
 
-        // 본인 예약 여부 체크
-        Reservations reservations = reservationRepository.findById(paymentHistory.getReservationId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다."));
+        Reservations reservations = reservationRepository.findByIdForUpdate(paymentHistory.getReservationId())
+                .orElseGet(() -> reservationRepository.findById(paymentHistory.getReservationId()).orElse(null));
+        if (reservations == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
         if (!reservations.getUsers().getUserId().equals(userId)) {
-            throw new IllegalArgumentException("본인 예약이 아닙니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
         }
 
-        if (paymentHistory.getPaymentStatusType() == PaymentStatusType.CANCEL) {
-            return PaymentResponse.of(paymentHistory);
-        }
+        if (paymentHistory.getPaymentStatusType() == PaymentStatusType.CANCEL) return PaymentResponse.of(paymentHistory);
 
         if (paymentHistory.getPaymentStatusType() == PaymentStatusType.PENDING) {
             paymentHistory.markCancel();
@@ -133,26 +158,20 @@ public class PaymentHistoryService {
 
         if (paymentHistory.getPaymentStatusType() == PaymentStatusType.SUCCESS) {
             Optional<Long> ticketIdOpt = ticketRepository.findIdByPaymentId(paymentId);
-
             if (ticketIdOpt.isPresent()) {
                 Long ticketId = ticketIdOpt.get();
-
-                 Tickets ticket = ticketRepository.findById(ticketId)
-                         .orElseThrow(() -> new IllegalStateException("티켓을 찾을 수 없습니다."));
-                 ticket.softDelete();
+                Tickets ticket = ticketRepository.findById(ticketId)
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "티켓을 찾을 수 없습니다."));
+                ticket.softDelete();
 
                 int unlinked = ticketRepository.unlinkPayment(ticketId, paymentId);
-                if (unlinked == 0) {
-                    throw new IllegalStateException("티켓 결제 연결 해제 실패");
-                }
+                if (unlinked == 0) throw new ResponseStatusException(HttpStatus.CONFLICT, "티켓 결제 연결 해제 실패");
             }
-
             paymentHistory.markCancel();
             return PaymentResponse.of(paymentHistory);
         }
 
-        // FAILED
-        paymentHistory.markCancel();
+        paymentHistory.markCancel(); // FAILED → CANCEL
         return PaymentResponse.of(paymentHistory);
     }
 

--- a/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
@@ -35,9 +35,9 @@ public class PaymentHistoryService {
             TicketService ticketService
     ) {
         this.paymentHistoryRepository = paymentHistoryRepository;
-        this.reservationRepository=reservationRepository;
-        this.ticketService=ticketService;
-        this.ticketRepository=ticketRepository;
+        this.reservationRepository = reservationRepository;
+        this.ticketService = ticketService;
+        this.ticketRepository = ticketRepository;
     }
 
     // 결제 생성(PENDING) - 상태만 관리하는 결제 + FK 주인(티켓)
@@ -66,7 +66,8 @@ public class PaymentHistoryService {
         // 2) 소유자 검증 (+ 필요시 예약 행 락)
         Reservations r = reservationRepository.findByIdForUpdate(req.getReservationId())
                 .orElseGet(() -> reservationRepository.findById(req.getReservationId()).orElse(null));
-        if (r == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
+        if (r == null)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
         if (!r.getUsers().getUserId().equals(userId)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
         }
@@ -83,7 +84,8 @@ public class PaymentHistoryService {
             Optional<PaymentHistory> dup =
                     paymentHistoryRepository.findByReservationIdAndIdempotencyKey(
                             req.getReservationId(), req.getIdempotencyKey());
-            if (dup.isPresent()) return PaymentResponse.of(dup.get());
+            if (dup.isPresent())
+                return PaymentResponse.of(dup.get());
 
             // 3-2) 동일 예약에 PENDING이 이미 있는 경우 (상태 유니크 충돌)
             if (paymentHistoryRepository.existsPendingByReservation(req.getReservationId())) {
@@ -110,7 +112,8 @@ public class PaymentHistoryService {
         //  예약 행 선점
         Reservations reservations = reservationRepository.findByIdForUpdate(req.getReservationId())
                 .orElseGet(() -> reservationRepository.findById(req.getReservationId()).orElse(null));
-        if (reservations == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
+        if (reservations == null)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
         if (!reservations.getUsers().getUserId().equals(userId)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
         }
@@ -118,7 +121,8 @@ public class PaymentHistoryService {
         // 이미 링크된 티켓이면 멱등 성공
         Optional<Long> linkedTicketIdOpt = ticketRepository.findIdByPaymentId(paymentId);
         if (linkedTicketIdOpt.isPresent()) {
-            if (paymentHistory.getPaymentStatusType() == PaymentStatusType.PENDING) paymentHistory.markSuccess();
+            if (paymentHistory.getPaymentStatusType() == PaymentStatusType.PENDING)
+                paymentHistory.markSuccess();
             return PaymentResponse.of(paymentHistory);
         }
 
@@ -133,7 +137,8 @@ public class PaymentHistoryService {
         TicketResponseDto ticket = ticketService.createTicket(ticketReq);
 
         int updated = ticketRepository.linkPayment(ticket.getTicketId(), paymentHistory);
-        if (updated == 0) throw new ResponseStatusException(HttpStatus.CONFLICT, "티켓 결제 연결 실패");
+        if (updated == 0)
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "티켓 결제 연결 실패");
 
         paymentHistory.markSuccess();
         return PaymentResponse.of(paymentHistory);
@@ -147,12 +152,14 @@ public class PaymentHistoryService {
 
         Reservations reservations = reservationRepository.findByIdForUpdate(paymentHistory.getReservationId())
                 .orElseGet(() -> reservationRepository.findById(paymentHistory.getReservationId()).orElse(null));
-        if (reservations == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
+        if (reservations == null)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
         if (!reservations.getUsers().getUserId().equals(userId)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
         }
 
-        if (paymentHistory.getPaymentStatusType() == PaymentStatusType.CANCEL) return PaymentResponse.of(paymentHistory);
+        if (paymentHistory.getPaymentStatusType() == PaymentStatusType.CANCEL)
+            return PaymentResponse.of(paymentHistory);
 
         if (paymentHistory.getPaymentStatusType() == PaymentStatusType.PENDING) {
             paymentHistory.markCancel();
@@ -168,7 +175,8 @@ public class PaymentHistoryService {
                 ticket.softDelete();
 
                 int unlinked = ticketRepository.unlinkPayment(ticketId, paymentId);
-                if (unlinked == 0) throw new ResponseStatusException(HttpStatus.CONFLICT, "티켓 결제 연결 해제 실패");
+                if (unlinked == 0)
+                    throw new ResponseStatusException(HttpStatus.CONFLICT, "티켓 결제 연결 해제 실패");
             }
             paymentHistory.markCancel();
             return PaymentResponse.of(paymentHistory);

--- a/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
+++ b/src/main/java/com/example/momentix/domain/paymenthistory/service/PaymentHistoryService.java
@@ -44,56 +44,59 @@ public class PaymentHistoryService {
     //idempotencyKey가 같으면 항상 같은 결과를 반환(중복 생성 방지)
     //(reservationId, status) UNIQUE로 동일 예약의 PENDING 2개 생성 불가
     @Transactional
-    public PaymentResponse create(Long userId, PaymentCreateRequest paymentCreateRequest) {
-        if (paymentCreateRequest.getIdempotencyKey() == null || paymentCreateRequest.getIdempotencyKey().isBlank()) {
+    public PaymentResponse create(Long userId, PaymentCreateRequest req) {
+        if (req.getIdempotencyKey() == null || req.getIdempotencyKey().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "idempotencyKey가 필요합니다.");
         }
 
-        // 1) 기존 생성 건 있으면 그대로 반환
-        Optional<PaymentHistory> existing = paymentHistoryRepository.findByIdempotencyKey(paymentCreateRequest.getIdempotencyKey());
+        // 1) 같은 예약 + 같은 멱등키면 기존 결과 그대로 반환
+        Optional<PaymentHistory> existing =
+                paymentHistoryRepository.findByReservationIdAndIdempotencyKey(
+                        req.getReservationId(), req.getIdempotencyKey());
+
         if (existing.isPresent()) {
-            // 소유자/예약 검증만 추가 확인
-            Reservations reservations = reservationRepository.findById(existing.get().getReservationId())
+            Reservations r = reservationRepository.findById(existing.get().getReservationId())
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."));
-            if (!reservations.getUsers().getUserId().equals(userId)) {
+            if (!r.getUsers().getUserId().equals(userId)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
             }
             return PaymentResponse.of(existing.get());
         }
 
-        // 2) 소유자 검증 (+ 필요시 예약 행에 락)
-        Reservations reservations = reservationRepository.findByIdForUpdate(paymentCreateRequest.getReservationId())
-                .orElseGet(() -> reservationRepository.findById(paymentCreateRequest.getReservationId()).orElse(null));
-        if (reservations == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
-        }
-        if (!reservations.getUsers().getUserId().equals(userId)) {
+        // 2) 소유자 검증 (+ 필요시 예약 행 락)
+        Reservations r = reservationRepository.findByIdForUpdate(req.getReservationId())
+                .orElseGet(() -> reservationRepository.findById(req.getReservationId()).orElse(null));
+        if (r == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다.");
+        if (!r.getUsers().getUserId().equals(userId)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 예약이 아닙니다.");
         }
 
-        // 3) 생성 시도: 유니크 제약이 중복을 근본 차단
-        PaymentHistory paymentHistory = PaymentHistory.create(
-                paymentCreateRequest.getReservationId(),
-                paymentCreateRequest.getPayer(),
-                paymentCreateRequest.getPaymentMethod(),
-                paymentCreateRequest.getPaymentPrice(),
-                paymentCreateRequest.getIdempotencyKey()
-        );
+        // 3) 생성 시도
+        PaymentHistory ph = PaymentHistory.create(
+                req.getReservationId(), req.getPayer(), req.getPaymentMethod(),
+                req.getPaymentPrice(), req.getIdempotencyKey());
 
         try {
-            paymentHistoryRepository.saveAndFlush(paymentHistory); // 즉시 반영하여 유니크 위반을 조기에 감지
+            paymentHistoryRepository.saveAndFlush(ph);
         } catch (DataIntegrityViolationException e) {
-            // 3-1) 멱등 키 충돌 → 기존 엔티티 반환
-            Optional<PaymentHistory> dup = paymentHistoryRepository.findByIdempotencyKey(paymentCreateRequest.getIdempotencyKey());
-            if (dup.isPresent()) {
-                return PaymentResponse.of(dup.get());
+            // 3-1) 더블클릭/재시도 등으로 이미 같은 (reservationId, idempotencyKey)가 들어간 경우 → 기존 반환
+            Optional<PaymentHistory> dup =
+                    paymentHistoryRepository.findByReservationIdAndIdempotencyKey(
+                            req.getReservationId(), req.getIdempotencyKey());
+            if (dup.isPresent()) return PaymentResponse.of(dup.get());
+
+            // 3-2) 동일 예약에 PENDING이 이미 있는 경우 (상태 유니크 충돌)
+            if (paymentHistoryRepository.existsPendingByReservation(req.getReservationId())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 이 예약에 결제 대기 건이 존재합니다.");
             }
-            // 3-2) 상태 유니크 충돌 (동일 예약의 PENDING 존재 등)
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 동일 예약에 해당 상태의 결제가 존재합니다.");
+
+            // 기타 제약 위반
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "결제 생성 중 제약조건 위반");
         }
 
-        return PaymentResponse.of(paymentHistory);
+        return PaymentResponse.of(ph);
     }
+
 
     // 결제 확정 (비관적 락 + 멱등)
     @Transactional

--- a/src/main/java/com/example/momentix/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/momentix/domain/reservation/repository/ReservationRepository.java
@@ -3,9 +3,9 @@ package com.example.momentix.domain.reservation.repository;
 
 import com.example.momentix.domain.reservation.entity.ReservationStatusType;
 import com.example.momentix.domain.reservation.entity.Reservations;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -21,12 +21,19 @@ public interface ReservationRepository extends JpaRepository<Reservations, Long>
             " and r.reservationStatusType in (:active)" +
             " order by r.reservationId desc")
     List<Reservations> findActiveByUsers_UsersIdAndEvents_Id(
-            @Param("usersId")Long usersId,
-            @Param("eventsId")Long eventsId,
-            @Param("active")List<ReservationStatusType> draft);
+            @Param("usersId") Long usersId,
+            @Param("eventsId") Long eventsId,
+            @Param("active") List<ReservationStatusType> draft);
 
     @EntityGraph(attributePaths = {"events"})
     Optional<Reservations> findByReservationIdAndUsers_UserId(Long reservationId, Long userId);
+
     @EntityGraph(attributePaths = {"events"})
     List<Reservations> findByUsers_UserIdOrderByReservationIdDesc(Long userId);
+
+    // 결제 - 동시성 이슈 고려함(비관적 락: PK 경로를 reservationId로)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000")) // 5초 대기 (DB별 지원)
+    @Query("select reservations from Reservations reservations where reservations.reservationId = :id")
+    Optional<Reservations> findByIdForUpdate(@Param("id") Long id);
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

아..결제 대기 스레드 군단 보여드리고 했는데
예매과정이 빡세서 나중에 보여드리겠습니다

다음 사진은 결제 완료 스레드 군단과 DB입니다.
JMeter 사용.
<img width="1920" height="1080" alt="결제성공JM" src="https://github.com/user-attachments/assets/0b869a55-c5d9-4856-8432-33df73ec44e5" />

<img width="1920" height="1080" alt="결제성공DB" src="https://github.com/user-attachments/assets/f04d67f6-2fd3-49a6-8d22-cabb049c295b" />


#### 비관적 락 + 멱등키로 동시성 제어
결제 요청 시 reservation과 payment_history 행 단위로 비관적 락을 걸어서 동시에 수정되지 않게 막았습니다

예약은 결제의 주체이기 때문에, 같은 예약에 대해 여러 결제가 동시에 들어올 수 있습니다. 그래서 결제 테이블만 락 거는 게 아니라 예약 행에도 락을 걸어야 하나의 예약 → 하나의 결제 원칙이 보장됩니다.


멱등키란?
클라이언트가 동일한 요청을 여러 번 보내더라도 서버가 한 번만 처리하도록 하여 데이터의 중복 처리를 막는 데 사용하는 고유한 식별자



## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
